### PR TITLE
propagate labels from app to resources

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ generate: controller-gen
 	$(CONTROLLER_GEN) crd:trivialVersions=true rbac:roleName=manager-role webhook paths="./pkg/apis/..." output:crd:artifacts:config=config/crd/bases
 
 mocks:
-	cd pkg/ && mockery -inpkg -all -case snake
+	cd pkg/ && mockery --inpackage --all --case snake
 
 # find or download controller-gen
 # download controller-gen if necessary

--- a/go.mod
+++ b/go.mod
@@ -14,5 +14,6 @@ require (
 	golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e // indirect
 	k8s.io/api v0.17.2
 	k8s.io/apimachinery v0.17.2
+	k8s.io/client-go v0.17.2 // indirect
 	sigs.k8s.io/controller-runtime v0.5.0
 )

--- a/go.mod
+++ b/go.mod
@@ -9,11 +9,10 @@ require (
 	github.com/mitchellh/mapstructure v1.1.2
 	github.com/sirupsen/logrus v1.4.2
 	github.com/spf13/pflag v1.0.5
-	github.com/spf13/viper v1.7.0
+	github.com/spf13/viper v1.3.2
 	github.com/stretchr/testify v1.6.1
 	golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e // indirect
 	k8s.io/api v0.17.2
 	k8s.io/apimachinery v0.17.2
-	k8s.io/client-go v0.17.2
 	sigs.k8s.io/controller-runtime v0.5.0
 )

--- a/go.mod
+++ b/go.mod
@@ -9,10 +9,11 @@ require (
 	github.com/mitchellh/mapstructure v1.1.2
 	github.com/sirupsen/logrus v1.4.2
 	github.com/spf13/pflag v1.0.5
-	github.com/spf13/viper v1.3.2
+	github.com/spf13/viper v1.7.0
 	github.com/stretchr/testify v1.6.1
 	golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e // indirect
 	k8s.io/api v0.17.2
 	k8s.io/apimachinery v0.17.2
+	k8s.io/client-go v0.17.2
 	sigs.k8s.io/controller-runtime v0.5.0
 )

--- a/pkg/apis/nais.io/v1alpha1/application_objectmeta.go
+++ b/pkg/apis/nais.io/v1alpha1/application_objectmeta.go
@@ -10,23 +10,23 @@ import (
 )
 
 func (in *Application) CreateObjectMeta() metav1.ObjectMeta {
-	meta := metav1.ObjectMeta{
+	labels := map[string]string{}
+
+	for k, v := range in.Labels {
+		labels[k] = v
+	}
+
+	labels["app"] = in.Name
+
+	return metav1.ObjectMeta{
 		Name:      in.Name,
 		Namespace: in.Namespace,
-		Labels: map[string]string{},
+		Labels:    labels,
 		Annotations: map[string]string{
 			DeploymentCorrelationIDAnnotation: in.CorrelationID(),
 		},
 		OwnerReferences: in.OwnerReferences(in),
 	}
-
-	for k, v := range in.Labels {
-		meta.Labels[k] = v
-	}
-
-	meta.Labels["app"] = in.Name
-
-	return meta
 }
 
 // We concatenate name, namespace and add a hash in order to avoid duplicate names when creating service accounts in common service accounts namespace.

--- a/pkg/apis/nais.io/v1alpha1/application_objectmeta.go
+++ b/pkg/apis/nais.io/v1alpha1/application_objectmeta.go
@@ -10,18 +10,23 @@ import (
 )
 
 func (in *Application) CreateObjectMeta() metav1.ObjectMeta {
-	return metav1.ObjectMeta{
+	meta := metav1.ObjectMeta{
 		Name:      in.Name,
 		Namespace: in.Namespace,
-		Labels: map[string]string{
-			"app":  in.Name,
-			"team": in.Labels["team"],
-		},
+		Labels: map[string]string{},
 		Annotations: map[string]string{
 			DeploymentCorrelationIDAnnotation: in.CorrelationID(),
 		},
 		OwnerReferences: in.OwnerReferences(in),
 	}
+
+	for k, v := range in.Labels {
+		meta.Labels[k] = v
+	}
+
+	meta.Labels["app"] = in.Name
+
+	return meta
 }
 
 // We concatenate name, namespace and add a hash in order to avoid duplicate names when creating service accounts in common service accounts namespace.

--- a/pkg/apis/nais.io/v1alpha1/application_objectmeta_test.go
+++ b/pkg/apis/nais.io/v1alpha1/application_objectmeta_test.go
@@ -20,13 +20,13 @@ func TestApplication_CreateObjectMeta(t *testing.T) {
 				ObjectMeta: v1.ObjectMeta{
 					Name:      app,
 					Namespace: namespace,
-					Labels:    map[string]string{
+					Labels: map[string]string{
 						"team": team,
 					},
 				},
 			},
 			map[string]string{
-				"app": app,
+				"app":  app,
 				"team": team,
 			},
 		},
@@ -36,16 +36,16 @@ func TestApplication_CreateObjectMeta(t *testing.T) {
 				ObjectMeta: v1.ObjectMeta{
 					Name:      app,
 					Namespace: namespace,
-					Labels:    map[string]string{
+					Labels: map[string]string{
 						"team": team,
-						key: value,
+						key:    value,
 					},
 				},
 			},
 			map[string]string{
-				"app": app,
+				"app":  app,
 				"team": team,
-				key: value,
+				key:    value,
 			},
 		},
 		{
@@ -54,14 +54,14 @@ func TestApplication_CreateObjectMeta(t *testing.T) {
 				ObjectMeta: v1.ObjectMeta{
 					Name:      app,
 					Namespace: namespace,
-					Labels:    map[string]string{
+					Labels: map[string]string{
 						"team": team,
-						"app": "ignored",
+						"app":  "ignored",
 					},
 				},
 			},
 			map[string]string{
-				"app": app,
+				"app":  app,
 				"team": team,
 			},
 		},

--- a/pkg/apis/nais.io/v1alpha1/application_objectmeta_test.go
+++ b/pkg/apis/nais.io/v1alpha1/application_objectmeta_test.go
@@ -1,0 +1,77 @@
+package nais_io_v1alpha1
+
+import (
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"reflect"
+	"testing"
+)
+
+func TestApplication_CreateObjectMeta(t *testing.T) {
+	const app, namespace, team, key, value = "myapp", "mynamespace", "myteam", "key", "value"
+
+	tests := []struct {
+		name string
+		in   *Application
+		want map[string]string
+	}{
+		{
+			"test object meta plain",
+			&Application{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      app,
+					Namespace: namespace,
+					Labels:    map[string]string{
+						"team": team,
+					},
+				},
+			},
+			map[string]string{
+				"app": app,
+				"team": team,
+			},
+		},
+		{
+			"test object meta custom label",
+			&Application{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      app,
+					Namespace: namespace,
+					Labels:    map[string]string{
+						"team": team,
+						key: value,
+					},
+				},
+			},
+			map[string]string{
+				"app": app,
+				"team": team,
+				key: value,
+			},
+		},
+		{
+			"test object meta app label not overrideable",
+			&Application{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      app,
+					Namespace: namespace,
+					Labels:    map[string]string{
+						"team": team,
+						"app": "ignored",
+					},
+				},
+			},
+			map[string]string{
+				"app": app,
+				"team": team,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.in.CreateObjectMeta()
+			if !reflect.DeepEqual(got.Labels, tt.want) {
+				t.Errorf("CreateObjectMeta() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/apis/nais.io/v1alpha1/application_objectmeta_test.go
+++ b/pkg/apis/nais.io/v1alpha1/application_objectmeta_test.go
@@ -70,7 +70,7 @@ func TestApplication_CreateObjectMeta(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got := tt.in.CreateObjectMeta()
 			if !reflect.DeepEqual(got.Labels, tt.want) {
-				t.Errorf("CreateObjectMeta() = %v, want %v", got, tt.want)
+				t.Errorf("CreateObjectMeta().Labels = %v, want %v", got.Labels, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
`naiserator` tests pass with this version (tested using `go mod edit -replace github.com/nais/liberator=../liberator`)