### PR TITLE
fiks for bruk i intelij

### DIFF
--- a/config/crd/bases/nais.io_applications.yaml
+++ b/config/crd/bases/nais.io_applications.yaml
@@ -367,7 +367,7 @@ spec:
               type: string
             ingresses:
               items:
-                pattern: ^https:\/\/
+                pattern: ^https:\/\/.*
                 type: string
               type: array
             kafka:


### PR DESCRIPTION
Vet ikke om dette vil ødlege noe for dere

^https:\/\/ matcher bare på https:// ikke noe mere
intelij gir da feil på alle urler når man prøver og bruke denne til  validering der