### PR TITLE
add: more info about topicConfig and kubebuilder validation

### DIFF
--- a/config/crd/bases/kafka.nais.io_topics.yaml
+++ b/config/crd/bases/kafka.nais.io_topics.yaml
@@ -81,7 +81,7 @@ spec:
                   enum:
                   - delete
                   - compact
-                  - both
+                  - compact,delete
                   type: string
                 minimumInSyncReplicas:
                   description: When a producer sets acks to "all" (or "-1"), `min.insync.replicas`

--- a/config/crd/bases/kafka.nais.io_topics.yaml
+++ b/config/crd/bases/kafka.nais.io_topics.yaml
@@ -45,19 +45,26 @@ spec:
         metadata:
           type: object
         spec:
+          description: TopicSpec is a specification of the desired behavior of the
+            topic.
           properties:
             acl:
               items:
+                description: TopicACL describes the access granted for the topic.
                 properties:
                   access:
+                    description: Access type granted for a application. Defaults to
+                      `readwrite`.
                     enum:
                     - read
                     - write
                     - readwrite
                     type: string
                   application:
+                    description: The name of the specified application
                     type: string
                   team:
+                    description: The team of the specified application
                     type: string
                 required:
                 - access
@@ -68,16 +75,46 @@ spec:
             config:
               properties:
                 cleanupPolicy:
+                  description: CleanupPolicy is either "delete" or "compact" or both.
+                    This designates the retention policy to use on old log segments.
+                    Defaults to `delete`.
+                  enum:
+                  - delete
+                  - compact
+                  - both
                   type: string
                 minimumInSyncReplicas:
+                  description: When a producer sets acks to "all" (or "-1"), `min.insync.replicas`
+                    specifies the minimum number of replicas that must acknowledge
+                    a write for the write to be considered successful. Defaults to
+                    `1`.
+                  maximum: 7
+                  minimum: 1
                   type: integer
                 partitions:
+                  description: The default number of log partitions per topic. Defaults
+                    to `1`.
+                  maximum: 1000000
+                  minimum: 1
                   type: integer
                 replication:
+                  description: The default replication factor for created topics.
+                    Defaults to `3`.
+                  minimum: 1
                   type: integer
                 retentionBytes:
+                  description: Configuration controls the maximum size a partition
+                    can grow to before we will discard old log segments to free up
+                    space if we are using the "delete" retention policy. By default
+                    there is no size limit only a time limit. Since this limit is
+                    enforced at the partition level, multiply it by the number of
+                    partitions to compute the topic retention in bytes. Defaults to
+                    `-1`.
                   type: integer
                 retentionHours:
+                  description: The number of hours to keep a log file before deleting
+                    it. Defaults to `72`.
+                  maximum: 2562047788015
                   type: integer
               type: object
             pool:

--- a/pkg/apis/kafka.nais.io/v1/topic_types.go
+++ b/pkg/apis/kafka.nais.io/v1/topic_types.go
@@ -18,9 +18,6 @@ const (
 
 	Finalizer            = "kafkarator.kafka.nais.io"
 	RemoveDataAnnotation = "kafka.nais.io/removeDataWhenResourceIsDeleted"
-
-	BothCleanupPolicies = "both"
-	CompactDelete       = "compact,delete"
 )
 
 func init() {
@@ -53,7 +50,7 @@ type Config struct {
 	// CleanupPolicy is either "delete" or "compact" or both.
 	// This designates the retention policy to use on old log segments.
 	// Defaults to `delete`.
-	// +kubebuilder:validation:Enum=delete;compact;both
+	// +kubebuilder:validation:Enum=delete;compact;"compact,delete"
 	CleanupPolicy *string `json:"cleanupPolicy,omitempty"`
 	// When a producer sets acks to "all" (or "-1"), `min.insync.replicas` specifies the minimum number of replicas
 	// that must acknowledge a write for the write to be considered successful.
@@ -151,18 +148,6 @@ func (in *Topic) RemoveFinalizer() {
 
 func (in Topic) FullName() string {
 	return in.Namespace + "." + in.Name
-}
-
-func (in Topic) CleanupPolicy() *string {
-	var compactDelete = CompactDelete
-	if in.Spec.Config == nil {
-		return nil
-	}
-
-	if in.Spec.Config.CleanupPolicy != nil && *in.Spec.Config.CleanupPolicy == BothCleanupPolicies {
-		return &compactDelete
-	}
-	return in.Spec.Config.CleanupPolicy
 }
 
 func (in TopicACL) Username() string {

--- a/pkg/apis/kafka.nais.io/v1/topic_types.go
+++ b/pkg/apis/kafka.nais.io/v1/topic_types.go
@@ -2,9 +2,8 @@ package kafka_nais_io_v1
 
 import (
 	"fmt"
-	"strconv"
-
 	aiven_nais_io_v1 "github.com/nais/liberator/pkg/apis/aiven.nais.io/v1"
+	"strconv"
 
 	"github.com/nais/liberator/pkg/namegen"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -19,6 +18,8 @@ const (
 
 	Finalizer            = "kafkarator.kafka.nais.io"
 	RemoveDataAnnotation = "kafka.nais.io/removeDataWhenResourceIsDeleted"
+
+	BothCleanupPolicies = "both"
 )
 
 func init() {
@@ -51,7 +52,7 @@ type Config struct {
 	// CleanupPolicy is either "delete" or "compact" or both.
 	// This designates the retention policy to use on old log segments.
 	// Defaults to `delete`.
-	// +kubebuilder:validation:Enum=delete;compact;compact,delete
+	// +kubebuilder:validation:Enum=delete;compact;both
 	// +optional
 	CleanupPolicy         *string `json:"cleanupPolicy,omitempty"`
 	// When a producer sets acks to "all" (or "-1"), `min.insync.replicas` specifies the minimum number of replicas
@@ -154,6 +155,13 @@ func (in *Topic) RemoveFinalizer() {
 
 func (in Topic) FullName() string {
 	return in.Namespace + "." + in.Name
+}
+
+func (in Topic) CleanupPolicy() string {
+	if *in.Spec.Config.CleanupPolicy != BothCleanupPolicies {
+		return *in.Spec.Config.CleanupPolicy
+	}
+	return "compact,delete"
 }
 
 func (in TopicACL) Username() string {

--- a/pkg/apis/kafka.nais.io/v1/topic_types.go
+++ b/pkg/apis/kafka.nais.io/v1/topic_types.go
@@ -157,11 +157,12 @@ func (in Topic) FullName() string {
 	return in.Namespace + "." + in.Name
 }
 
-func (in Topic) CleanupPolicy() string {
+func (in Topic) CleanupPolicy() *string {
+	var compactDeletion = "compact,deletion"
 	if *in.Spec.Config.CleanupPolicy != BothCleanupPolicies {
-		return *in.Spec.Config.CleanupPolicy
+		return in.Spec.Config.CleanupPolicy
 	}
-	return "compact,delete"
+	return &compactDeletion
 }
 
 func (in TopicACL) Username() string {

--- a/pkg/apis/kafka.nais.io/v1/topic_types.go
+++ b/pkg/apis/kafka.nais.io/v1/topic_types.go
@@ -158,11 +158,11 @@ func (in Topic) FullName() string {
 }
 
 func (in Topic) CleanupPolicy() *string {
-	var compactDeletion = "compact,deletion"
+	var compactDelete = "compact,delete"
 	if *in.Spec.Config.CleanupPolicy != BothCleanupPolicies {
 		return in.Spec.Config.CleanupPolicy
 	}
-	return &compactDeletion
+	return &compactDelete
 }
 
 func (in TopicACL) Username() string {

--- a/pkg/apis/kafka.nais.io/v1/topic_types.go
+++ b/pkg/apis/kafka.nais.io/v1/topic_types.go
@@ -2,8 +2,9 @@ package kafka_nais_io_v1
 
 import (
 	"fmt"
-	aiven_nais_io_v1 "github.com/nais/liberator/pkg/apis/aiven.nais.io/v1"
 	"strconv"
+
+	aiven_nais_io_v1 "github.com/nais/liberator/pkg/apis/aiven.nais.io/v1"
 
 	"github.com/nais/liberator/pkg/namegen"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -47,14 +48,44 @@ type Topic struct {
 }
 
 type Config struct {
+	// CleanupPolicy is either "delete" or "compact" or both.
+	// This designates the retention policy to use on old log segments.
+	// Defaults to `delete`.
+	// +kubebuilder:validation:Enum=delete;compact;compact,delete
+	// +optional
 	CleanupPolicy         *string `json:"cleanupPolicy,omitempty"`
+	// When a producer sets acks to "all" (or "-1"), `min.insync.replicas` specifies the minimum number of replicas
+	// that must acknowledge a write for the write to be considered successful.
+	// Defaults to `1`.
+	// +kubebuilder:validation:Minimum=1
+	// +kubebuilder:validation:Maximum=7
+	// +optional
 	MinimumInSyncReplicas *int    `json:"minimumInSyncReplicas,omitempty"`
+	// The default number of log partitions per topic.
+	// Defaults to `1`.
+	// +kubebuilder:validation:Minimum=1
+	// +kubebuilder:validation:Maximum=1000000
+	// +optional
 	Partitions            *int    `json:"partitions,omitempty"`
+	// The default replication factor for created topics.
+	// Defaults to `3`.
+	// +kubebuilder:validation:Minimum=1
+	// +optional
 	Replication           *int    `json:"replication,omitempty"`
+	// Configuration controls the maximum size a partition can grow to before we will discard old log segments
+	// to free up space if we are using the "delete" retention policy. By default there is no size limit only a time limit.
+	// Since this limit is enforced at the partition level, multiply it by the number of partitions to compute the topic retention in bytes.
+	// Defaults to `-1`.
+	// +optional
 	RetentionBytes        *int    `json:"retentionBytes,omitempty"`
+	// The number of hours to keep a log file before deleting it.
+	// Defaults to `72`.
+	// +kubebuilder:validation:Maximum=2562047788015
+	// +optional
 	RetentionHours        *int    `json:"retentionHours,omitempty"`
 }
 
+// TopicSpec is a specification of the desired behavior of the topic.
 type TopicSpec struct {
 	Pool   string    `json:"pool"`
 	Config *Config   `json:"config,omitempty"`
@@ -73,10 +104,15 @@ type TopicStatus struct {
 
 type TopicACLs []TopicACL
 
+// TopicACL describes the access granted for the topic.
 type TopicACL struct {
+	// Access type granted for a application.
+	// Defaults to `readwrite`.
 	// +kubebuilder:validation:Enum=read;write;readwrite
 	Access      string `json:"access"`
+	// The name of the specified application
 	Application string `json:"application"`
+	// The team of the specified application
 	Team        string `json:"team"`
 }
 


### PR DESCRIPTION
Added support for `both` cleanup polices, as the documentation for Aiven supports both values `compact,delete`.

Dont know if this is something that is let out for a reason?