### PR TITLE
crd: disable preserveunknown fields

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ test:
 # Generate code
 generate: controller-gen
 	$(CONTROLLER_GEN) object paths="./pkg/apis/..."
-	$(CONTROLLER_GEN) crd:trivialVersions=true rbac:roleName=manager-role webhook paths="./pkg/apis/..." output:crd:artifacts:config=config/crd/bases
+	$(CONTROLLER_GEN) crd:trivialVersions=true,preserveUnknownFields=false rbac:roleName=manager-role webhook paths="./pkg/apis/..." output:crd:artifacts:config=config/crd/bases
 
 doc:
 	mkdir -p doc/output/application

--- a/config/crd/bases/aiven.nais.io_aivenapplications.yaml
+++ b/config/crd/bases/aiven.nais.io_aivenapplications.yaml
@@ -32,6 +32,7 @@ spec:
     shortNames:
     - aivenapp
     singular: aivenapplication
+  preserveUnknownFields: false
   scope: Namespaced
   subresources:
     status: {}

--- a/config/crd/bases/bigquery.cnrm.cloud.google.com_bigquerydatasets.yaml
+++ b/config/crd/bases/bigquery.cnrm.cloud.google.com_bigquerydatasets.yaml
@@ -14,6 +14,7 @@ spec:
     listKind: BigQueryDatasetList
     plural: bigquerydatasets
     singular: bigquerydataset
+  preserveUnknownFields: false
   scope: Namespaced
   validation:
     openAPIV3Schema:

--- a/config/crd/bases/iam.cnrm.cloud.google.com_iampolicies.yaml
+++ b/config/crd/bases/iam.cnrm.cloud.google.com_iampolicies.yaml
@@ -14,6 +14,7 @@ spec:
     listKind: IAMPolicyList
     plural: iampolicies
     singular: iampolicy
+  preserveUnknownFields: false
   scope: Namespaced
   validation:
     openAPIV3Schema:

--- a/config/crd/bases/iam.cnrm.cloud.google.com_iampolicymembers.yaml
+++ b/config/crd/bases/iam.cnrm.cloud.google.com_iampolicymembers.yaml
@@ -14,6 +14,7 @@ spec:
     listKind: IAMPolicyMemberList
     plural: iampolicymembers
     singular: iampolicymember
+  preserveUnknownFields: false
   scope: Namespaced
   validation:
     openAPIV3Schema:

--- a/config/crd/bases/iam.cnrm.cloud.google.com_iamserviceaccounts.yaml
+++ b/config/crd/bases/iam.cnrm.cloud.google.com_iamserviceaccounts.yaml
@@ -14,6 +14,7 @@ spec:
     listKind: IAMServiceAccountList
     plural: iamserviceaccounts
     singular: iamserviceaccount
+  preserveUnknownFields: false
   scope: Namespaced
   validation:
     openAPIV3Schema:

--- a/config/crd/bases/kafka.nais.io_topics.yaml
+++ b/config/crd/bases/kafka.nais.io_topics.yaml
@@ -27,6 +27,7 @@ spec:
     listKind: TopicList
     plural: topics
     singular: topic
+  preserveUnknownFields: false
   scope: Namespaced
   subresources: {}
   validation:

--- a/config/crd/bases/nais.io_alerts.yaml
+++ b/config/crd/bases/nais.io_alerts.yaml
@@ -18,6 +18,7 @@ spec:
     listKind: AlertList
     plural: alerts
     singular: alert
+  preserveUnknownFields: false
   scope: Namespaced
   subresources:
     status: {}

--- a/config/crd/bases/nais.io_applications.yaml
+++ b/config/crd/bases/nais.io_applications.yaml
@@ -26,6 +26,7 @@ spec:
     shortNames:
     - app
     singular: application
+  preserveUnknownFields: false
   scope: Namespaced
   subresources: {}
   validation:

--- a/config/crd/bases/nais.io_azureadapplications.yaml
+++ b/config/crd/bases/nais.io_azureadapplications.yaml
@@ -45,6 +45,7 @@ spec:
     shortNames:
     - azureapp
     singular: azureadapplication
+  preserveUnknownFields: false
   scope: Namespaced
   subresources:
     status: {}

--- a/config/crd/bases/nais.io_idportenclients.yaml
+++ b/config/crd/bases/nais.io_idportenclients.yaml
@@ -30,6 +30,7 @@ spec:
     listKind: IDPortenClientList
     plural: idportenclients
     singular: idportenclient
+  preserveUnknownFields: false
   scope: Namespaced
   subresources: {}
   validation:

--- a/config/crd/bases/nais.io_jwkers.yaml
+++ b/config/crd/bases/nais.io_jwkers.yaml
@@ -18,6 +18,7 @@ spec:
     listKind: JwkerList
     plural: jwkers
     singular: jwker
+  preserveUnknownFields: false
   scope: Namespaced
   subresources: {}
   validation:

--- a/config/crd/bases/nais.io_maskinportenclients.yaml
+++ b/config/crd/bases/nais.io_maskinportenclients.yaml
@@ -30,6 +30,7 @@ spec:
     listKind: MaskinportenClientList
     plural: maskinportenclients
     singular: maskinportenclient
+  preserveUnknownFields: false
   scope: Namespaced
   subresources: {}
   validation:

--- a/config/crd/bases/nais.io_naisjobs.yaml
+++ b/config/crd/bases/nais.io_naisjobs.yaml
@@ -29,6 +29,7 @@ spec:
     shortNames:
     - nj
     singular: naisjob
+  preserveUnknownFields: false
   scope: Namespaced
   subresources: {}
   validation:

--- a/config/crd/bases/sql.cnrm.cloud.google.com_sqldatabases.yaml
+++ b/config/crd/bases/sql.cnrm.cloud.google.com_sqldatabases.yaml
@@ -14,6 +14,7 @@ spec:
     listKind: SQLDatabaseList
     plural: sqldatabases
     singular: sqldatabase
+  preserveUnknownFields: false
   scope: Namespaced
   validation:
     openAPIV3Schema:

--- a/config/crd/bases/sql.cnrm.cloud.google.com_sqlinstances.yaml
+++ b/config/crd/bases/sql.cnrm.cloud.google.com_sqlinstances.yaml
@@ -14,6 +14,7 @@ spec:
     listKind: SQLInstanceList
     plural: sqlinstances
     singular: sqlinstance
+  preserveUnknownFields: false
   scope: Namespaced
   validation:
     openAPIV3Schema:

--- a/config/crd/bases/sql.cnrm.cloud.google.com_sqlusers.yaml
+++ b/config/crd/bases/sql.cnrm.cloud.google.com_sqlusers.yaml
@@ -14,6 +14,7 @@ spec:
     listKind: SQLUserList
     plural: sqlusers
     singular: sqluser
+  preserveUnknownFields: false
   scope: Namespaced
   validation:
     openAPIV3Schema:

--- a/config/crd/bases/storage.cnrm.cloud.google.com_storagebucketaccesscontrols.yaml
+++ b/config/crd/bases/storage.cnrm.cloud.google.com_storagebucketaccesscontrols.yaml
@@ -14,6 +14,7 @@ spec:
     listKind: StorageBucketAccessControlList
     plural: storagebucketaccesscontrols
     singular: storagebucketaccesscontrol
+  preserveUnknownFields: false
   scope: Namespaced
   validation:
     openAPIV3Schema:

--- a/config/crd/bases/storage.cnrm.cloud.google.com_storagebuckets.yaml
+++ b/config/crd/bases/storage.cnrm.cloud.google.com_storagebuckets.yaml
@@ -14,6 +14,7 @@ spec:
     listKind: StorageBucketList
     plural: storagebuckets
     singular: storagebucket
+  preserveUnknownFields: false
   scope: Namespaced
   validation:
     openAPIV3Schema:


### PR DESCRIPTION
See <https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#field-pruning>. 

This is the default for apiextensions/v1 CRDs, is required for apiextensions/v1beta1 CRDs from 1.19+, and will enable pruning of unknown fields. 

However, this change will break compatibility with k8s versions < 1.15. 

This allows for running `kubectl explain <resource>` which fetches the structural OpenAPI schema from the API server.

Before:

```shell
$ k explain app

KIND:     Application
VERSION:  nais.io/v1alpha1
DESCRIPTION:
     <empty>
```

After:

```shell
$ k explain app

KIND:     Application
VERSION:  nais.io/v1alpha1

DESCRIPTION:
     Application defines a NAIS application.

FIELDS:
   apiVersion   <string>
     APIVersion defines the versioned schema of this representation of an
     object. Servers should convert recognized schemas to the latest internal
     value, and may reject unrecognized values. More info:
     https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources

   kind <string>
     Kind is a string value representing the REST resource this object
     represents. Servers may infer this from the endpoint the client submits
     requests to. Cannot be updated. In CamelCase. More info:
     https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds

   metadata     <Object>
     Standard object's metadata. More info:
     https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata

   spec <Object> -required-
     ApplicationSpec contains the NAIS manifest. Please keep this list sorted
     for clarity.

   status       <Object>
     ApplicationStatus contains different NAIS status properties
```

```shell
$ k explain app.spec

KIND:     Application
VERSION:  nais.io/v1alpha1

RESOURCE: spec <Object>

DESCRIPTION:
     ApplicationSpec contains the NAIS manifest. Please keep this list sorted
     for clarity.

FIELDS:
   accessPolicy <Object>
     By default, no traffic is allowed between applications inside the cluster.
     Configure access policies to explicitly allow communication between
     applications. This is also used for granting inbound access in the context
     of Azure AD and TokenX clients.

   azure        <Object>
     Provisions and configures Azure resources.

   command      <[]string>
     Override command when starting Docker image.

   [...]
```