### PR TITLE
Generate and upload json-spec for nais and k8s resources.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -82,3 +82,33 @@ jobs:
         else
           echo "No changes; skip commit"
         fi
+
+  json-spec:
+    name: Generate and upload json-spec
+    if: github.ref == 'refs/heads/main'
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions/setup-go@v2
+      with:
+        go-version: "1.15"
+    - name: Generate json-spec
+      # The docker image used in build-json-spec.sh has expected errors, but returns non-0
+      continue-on-error: true
+      run: make doc && ./hack/build-json-spec.sh
+    - uses: actions-hub/gcloud@master
+      env:
+        PROJECT_ID: nais-json-schema-2c91
+        APPLICATION_CREDENTIALS: ${{ secrets.NAIS_JSON_SCHEMA_BUCKET_SA }}
+      with:
+        args: |
+          -qm \
+          -h 'Cache-Control:private, max-age=0, no-transform' \
+          cp -r \
+          doc/output/openapi/kubernetes \
+          doc/output/openapi/nais \
+          doc/output/openapi/nais-all.json \
+          doc/output/openapi/nais-k8s-all.json \
+          gs://nais-json-schema-2c91
+        cli: gsutil

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -94,10 +94,8 @@ jobs:
       with:
         go-version: "1.15"
     - name: Generate json-spec
-      # The docker image used in build-json-spec.sh has expected errors, but returns non-0
-      continue-on-error: true
       run: make doc && ./hack/build-json-spec.sh
-    - uses: actions-hub/gcloud@master
+    - uses: actions-hub/gcloud@356.0.0
       env:
         PROJECT_ID: nais-json-schema-2c91
         APPLICATION_CREDENTIALS: ${{ secrets.NAIS_JSON_SCHEMA_BUCKET_SA }}

--- a/Makefile
+++ b/Makefile
@@ -24,13 +24,14 @@ doc:
 	mkdir -p doc/output/application
 	mkdir -p doc/output/naisjob
 	mkdir -p doc/output/alert
+	mkdir -p doc/output/openapi/nais
 	go run cmd/docgen/docgen.go \
 		--dir ./pkg/apis/... \
 		--group nais.io \
 		--kind Application \
 		--reference-output doc/output/application/reference.md \
 		--example-output doc/output/application/example.md \
-		--json-schema-output doc/output/application-schema.json \
+		--openapi-output doc/output/openapi/nais \
 		--reference-template doc/templates/reference/application.md \
 		--example-template doc/templates/example/application.md \
 		;
@@ -40,6 +41,7 @@ doc:
 		--kind Naisjob \
 		--reference-output doc/output/naisjob/reference.md \
 		--example-output doc/output/naisjob/example.md \
+		--openapi-output doc/output/openapi/nais \
 		--reference-template doc/templates/reference/naisjob.md \
 		--example-template doc/templates/example/naisjob.md \
 		;
@@ -49,6 +51,7 @@ doc:
 		--kind Alert \
 		--reference-output doc/output/alert/reference.md \
 		--example-output doc/output/alert/example.md \
+		--openapi-output doc/output/openapi/nais \
 		--reference-template doc/templates/reference/alert.md \
 		--example-template doc/templates/example/alert.md \
 		;

--- a/hack/build-json-spec.sh
+++ b/hack/build-json-spec.sh
@@ -45,6 +45,3 @@ jq_k8s='
 '
 jq -s "$jq_k8s" "$OPENAPI_DIR/kubernetes/_definitions.json" "$OPENAPI_DIR/nais-all.json" > \
 		"$OPENAPI_DIR/nais-k8s-all.json"
-
-# Upload to k8s
-# gsutil -m  -h "Cache-Control:private, max-age=0, no-transform" cp -r "$OPENAPI_DIR/"{kubernetes,nais,nais-all.json,nais-k8s-all.json} $BUCKET

--- a/hack/build-json-spec.sh
+++ b/hack/build-json-spec.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+set -e
+
+K8S_VERSION=v1.19.12
+
+OPENAPI_DIR=$(pwd)/doc/output/openapi
+
+# Heavily inspired by https://github.com/yannh/kubernetes-json-schema/blob/master/build.sh
+OPENAPI2JSONSCHEMABIN="docker create -i ghcr.io/yannh/openapi2jsonschema:latest"
+
+# Generate json spec for k8s resources
+container=$($OPENAPI2JSONSCHEMABIN -o "schemas/kubernetes" --kubernetes --stand-alone --expanded --strict "https://raw.githubusercontent.com/kubernetes/kubernetes/${K8S_VERSION}/api/openapi-spec/swagger.json")
+set +e
+docker start -ai "$container"
+set -e
+rm -rf "$OPENAPI_DIR/kubernetes"
+docker cp "$container:/out/schemas/kubernetes" "$OPENAPI_DIR"
+docker rm "$container"
+
+# Make a json file with all nais resources
+echo '{"oneOf":[' > "$OPENAPI_DIR/nais-all.json"
+list=$(ls "$OPENAPI_DIR/nais/")
+mapfile -t FILES <<< "$list"
+for file in ${FILES[*]}; do
+	echo "{\"\$ref\":\"nais/$(basename "$file")\"}," >> "$OPENAPI_DIR/nais-all.json"
+done
+truncate -s-2 "$OPENAPI_DIR/nais-all.json"
+echo "]}" >> "$OPENAPI_DIR/nais-all.json"
+
+# Combine nais and k8s resources, but only those with an enum defined for the kind (otherwise there's completion problems)
+jq_k8s='
+	{
+		"oneOf":
+		(
+			.[1].oneOf +
+				(
+					.[0].definitions
+					| to_entries
+					| map(select(.value.properties.kind.enum))
+					| map({"$ref": ("kubernetes/_definitions.json#/definitions/"+ .key)})
+				)
+		)
+	}
+'
+jq -s "$jq_k8s" "$OPENAPI_DIR/kubernetes/_definitions.json" "$OPENAPI_DIR/nais-all.json" > \
+		"$OPENAPI_DIR/nais-k8s-all.json"
+
+# Upload to k8s
+# gsutil -m  -h "Cache-Control:private, max-age=0, no-transform" cp -r "$OPENAPI_DIR/"{kubernetes,nais,nais-all.json,nais-k8s-all.json} $BUCKET


### PR DESCRIPTION
This PR adds an extra step to the workflow which generates `json-spec` from our CRDs, as well as Kubernetes resources matching the version of Kubernetes we're running.

It uploads the files to a public bucket, and can be used in e.g. (tested) VSCode by installing [YAML extension](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml) and adding the following to settings.json:
```json
	"yaml.schemas": {
		"https://storage.googleapis.com/nais-json-schema-2c91/nais-k8s-all.json": ["nais.yaml", "nais/*", ".nais/*"],
	},
```

There's also a spec with only our CRDs, just replace `nais-k8s-all` with `nais-all` in the URL.

IntelliJ is supposed to support this feature as well, see https://www.jetbrains.com/help/go/json.html#ws_json_schema_add_custom