### PR TITLE
add public access prevention feature

### DIFF
--- a/pkg/apis/nais.io/v1/naiserator_types.go
+++ b/pkg/apis/nais.io/v1/naiserator_types.go
@@ -497,6 +497,11 @@ type CloudStorageBucket struct {
 	// +nais:doc:Link="https://cloud.google.com/storage/docs/uniform-bucket-level-access"
 	// +nais:doc:Default="false"
 	UniformBucketLevelAccess bool `json:"uniformBucketLevelAccess,omitempty"`
+	// Allows you to restrict public access to your buckets.
+	// When you enforce public access prevention on a bucket it is not possible to make the data in said bucket public through IAM policies or ACLs.
+	// +nais:doc:Link="https://cloud.google.com/storage/docs/public-access-prevention"
+	// +nais:doc:Default="false"
+	PublicAccessPrevention bool `json:"publicAccessPrevention,omitempty"`
 }
 
 type LifecycleCondition struct {

--- a/pkg/apis/nais.io/v1/naisjob_doc_example.go
+++ b/pkg/apis/nais.io/v1/naisjob_doc_example.go
@@ -221,6 +221,7 @@ func ExampleNaisjobForDocumentation() *Naisjob {
 							WithState:        "ARCHIVED",
 						},
 						UniformBucketLevelAccess: true,
+						PublicAccessPrevention:   false,
 					},
 				},
 				SqlInstances: []CloudSqlInstance{

--- a/pkg/apis/nais.io/v1/naisjob_doc_example.go
+++ b/pkg/apis/nais.io/v1/naisjob_doc_example.go
@@ -221,7 +221,7 @@ func ExampleNaisjobForDocumentation() *Naisjob {
 							WithState:        "ARCHIVED",
 						},
 						UniformBucketLevelAccess: true,
-						PublicAccessPrevention:   false,
+						PublicAccessPrevention:   true,
 					},
 				},
 				SqlInstances: []CloudSqlInstance{

--- a/pkg/apis/nais.io/v1alpha1/application_doc_example.go
+++ b/pkg/apis/nais.io/v1alpha1/application_doc_example.go
@@ -223,6 +223,7 @@ func ExampleApplicationForDocumentation() *Application {
 							WithState:        "ARCHIVED",
 						},
 						UniformBucketLevelAccess: true,
+						PublicAccessPrevention:   false,
 					},
 				},
 				SqlInstances: []nais_io_v1.CloudSqlInstance{

--- a/pkg/apis/nais.io/v1alpha1/application_doc_example.go
+++ b/pkg/apis/nais.io/v1alpha1/application_doc_example.go
@@ -223,7 +223,7 @@ func ExampleApplicationForDocumentation() *Application {
 							WithState:        "ARCHIVED",
 						},
 						UniformBucketLevelAccess: true,
-						PublicAccessPrevention:   false,
+						PublicAccessPrevention:   true,
 					},
 				},
 				SqlInstances: []nais_io_v1.CloudSqlInstance{

--- a/pkg/apis/storage.cnrm.cloud.google.com/v1beta1/types.go
+++ b/pkg/apis/storage.cnrm.cloud.google.com/v1beta1/types.go
@@ -24,6 +24,7 @@ type StorageBucketSpec struct {
 	ResourceID               string           `json:"resourceID,omitempty"`
 	Location                 string           `json:"location"`
 	UniformBucketLevelAccess bool             `json:"uniformBucketLevelAccess,omitempty"`
+	PublicAccessPrevention   string           `json:"publicAccessPrevention,omitempty"`
 	RetentionPolicy          *RetentionPolicy `json:"retentionPolicy,omitempty"`
 	LifecycleRules           []LifecycleRules `json:"lifecycleRule,omitempty"`
 }


### PR DESCRIPTION
- Need to wait until [configconnector](https://cloud.google.com/config-connector/docs/release-notes#January_19_2022) >= 1.71 is installed in clusters for `spec.publicAccessPrevention` in `StorageBucket` resource.

Co-authored-by: Kyrre Havik <kyrremann@gmail.com>