### PR TITLE
application, naisjob: remove unused fields

### DIFF
--- a/charts/templates/nais.io_applications.yaml
+++ b/charts/templates/nais.io_applications.yaml
@@ -121,29 +121,12 @@ spec:
                                 Must be specified if using protocols other than HTTPS.
                               items:
                                 properties:
-                                  name:
-                                    description: Human-readable identifier for this
-                                      rule.
-                                    type: string
                                   port:
                                     description: The port used for communication.
                                     format: int32
                                     type: integer
-                                  protocol:
-                                    description: The protocol used for communication.
-                                    enum:
-                                    - HTTP
-                                    - HTTPS
-                                    - GRPC
-                                    - HTTP2
-                                    - MONGO
-                                    - TCP
-                                    - TLS
-                                    type: string
                                 required:
-                                - name
                                 - port
-                                - protocol
                                 type: object
                               type: array
                           required:
@@ -264,10 +247,6 @@ spec:
                       enabled:
                         description: Enable the sidecar.
                         type: boolean
-                      errorPath:
-                        description: Absolute path to redirect the user to on authentication
-                          errors for custom error handling.
-                        type: string
                       resources:
                         description: Resource requirements for the sidecar container.
                         properties:
@@ -810,10 +789,6 @@ spec:
                       enabled:
                         description: Enable the sidecar.
                         type: boolean
-                      errorPath:
-                        description: Absolute path to redirect the user to on authentication
-                          errors for custom error handling.
-                        type: string
                       level:
                         description: Default security level for all authentication
                           requests.

--- a/charts/templates/nais.io_jwkers.yaml
+++ b/charts/templates/nais.io_jwkers.yaml
@@ -107,29 +107,12 @@ spec:
                                 Must be specified if using protocols other than HTTPS.
                               items:
                                 properties:
-                                  name:
-                                    description: Human-readable identifier for this
-                                      rule.
-                                    type: string
                                   port:
                                     description: The port used for communication.
                                     format: int32
                                     type: integer
-                                  protocol:
-                                    description: The protocol used for communication.
-                                    enum:
-                                    - HTTP
-                                    - HTTPS
-                                    - GRPC
-                                    - HTTP2
-                                    - MONGO
-                                    - TCP
-                                    - TLS
-                                    type: string
                                 required:
-                                - name
                                 - port
-                                - protocol
                                 type: object
                               type: array
                           required:

--- a/charts/templates/nais.io_naisjobs.yaml
+++ b/charts/templates/nais.io_naisjobs.yaml
@@ -124,29 +124,12 @@ spec:
                                 Must be specified if using protocols other than HTTPS.
                               items:
                                 properties:
-                                  name:
-                                    description: Human-readable identifier for this
-                                      rule.
-                                    type: string
                                   port:
                                     description: The port used for communication.
                                     format: int32
                                     type: integer
-                                  protocol:
-                                    description: The protocol used for communication.
-                                    enum:
-                                    - HTTP
-                                    - HTTPS
-                                    - GRPC
-                                    - HTTP2
-                                    - MONGO
-                                    - TCP
-                                    - TLS
-                                    type: string
                                 required:
-                                - name
                                 - port
-                                - protocol
                                 type: object
                               type: array
                           required:

--- a/config/crd/bases/nais.io_applications.yaml
+++ b/config/crd/bases/nais.io_applications.yaml
@@ -121,29 +121,12 @@ spec:
                                 Must be specified if using protocols other than HTTPS.
                               items:
                                 properties:
-                                  name:
-                                    description: Human-readable identifier for this
-                                      rule.
-                                    type: string
                                   port:
                                     description: The port used for communication.
                                     format: int32
                                     type: integer
-                                  protocol:
-                                    description: The protocol used for communication.
-                                    enum:
-                                    - HTTP
-                                    - HTTPS
-                                    - GRPC
-                                    - HTTP2
-                                    - MONGO
-                                    - TCP
-                                    - TLS
-                                    type: string
                                 required:
-                                - name
                                 - port
-                                - protocol
                                 type: object
                               type: array
                           required:
@@ -264,10 +247,6 @@ spec:
                       enabled:
                         description: Enable the sidecar.
                         type: boolean
-                      errorPath:
-                        description: Absolute path to redirect the user to on authentication
-                          errors for custom error handling.
-                        type: string
                       resources:
                         description: Resource requirements for the sidecar container.
                         properties:
@@ -810,10 +789,6 @@ spec:
                       enabled:
                         description: Enable the sidecar.
                         type: boolean
-                      errorPath:
-                        description: Absolute path to redirect the user to on authentication
-                          errors for custom error handling.
-                        type: string
                       level:
                         description: Default security level for all authentication
                           requests.

--- a/config/crd/bases/nais.io_jwkers.yaml
+++ b/config/crd/bases/nais.io_jwkers.yaml
@@ -107,29 +107,12 @@ spec:
                                 Must be specified if using protocols other than HTTPS.
                               items:
                                 properties:
-                                  name:
-                                    description: Human-readable identifier for this
-                                      rule.
-                                    type: string
                                   port:
                                     description: The port used for communication.
                                     format: int32
                                     type: integer
-                                  protocol:
-                                    description: The protocol used for communication.
-                                    enum:
-                                    - HTTP
-                                    - HTTPS
-                                    - GRPC
-                                    - HTTP2
-                                    - MONGO
-                                    - TCP
-                                    - TLS
-                                    type: string
                                 required:
-                                - name
                                 - port
-                                - protocol
                                 type: object
                               type: array
                           required:

--- a/config/crd/bases/nais.io_naisjobs.yaml
+++ b/config/crd/bases/nais.io_naisjobs.yaml
@@ -124,29 +124,12 @@ spec:
                                 Must be specified if using protocols other than HTTPS.
                               items:
                                 properties:
-                                  name:
-                                    description: Human-readable identifier for this
-                                      rule.
-                                    type: string
                                   port:
                                     description: The port used for communication.
                                     format: int32
                                     type: integer
-                                  protocol:
-                                    description: The protocol used for communication.
-                                    enum:
-                                    - HTTP
-                                    - HTTPS
-                                    - GRPC
-                                    - HTTP2
-                                    - MONGO
-                                    - TCP
-                                    - TLS
-                                    type: string
                                 required:
-                                - name
                                 - port
-                                - protocol
                                 type: object
                               type: array
                           required:

--- a/pkg/apis/nais.io/v1/accesspolicy.go
+++ b/pkg/apis/nais.io/v1/accesspolicy.go
@@ -1,13 +1,8 @@
 package nais_io_v1
 
 type AccessPolicyPortRule struct {
-	// Human-readable identifier for this rule.
-	Name string `json:"name"`
 	// The port used for communication.
 	Port uint32 `json:"port"`
-	// The protocol used for communication.
-	// +kubebuilder:validation:Enum=HTTP;HTTPS;GRPC;HTTP2;MONGO;TCP;TLS
-	Protocol string `json:"protocol"`
 }
 
 type AccessPolicyExternalRule struct {

--- a/pkg/apis/nais.io/v1/naiserator_types.go
+++ b/pkg/apis/nais.io/v1/naiserator_types.go
@@ -687,11 +687,8 @@ type Wonderwall struct {
 	AutoLoginIgnorePaths []WonderwallIgnorePaths `json:"autoLoginIgnorePaths,omitempty"`
 	// Enable the sidecar.
 	Enabled bool `json:"enabled"`
-	// Absolute path to redirect the user to on authentication errors for custom error handling.
-	// +nais:doc:Link="https://doc.nais.io/appendix/wonderwall/#4-error-handling"
-	ErrorPath string `json:"errorPath,omitempty"`
 	// Resource requirements for the sidecar container.
-	// +nais:doc:Link="https://doc.nais.io/appendix/wonderwall/#5-resource-requirements"
+	// +nais:doc:Link="https://doc.nais.io/appendix/wonderwall/#4-resource-requirements"
 	Resources *ResourceRequirements `json:"resources,omitempty"`
 }
 

--- a/pkg/apis/nais.io/v1/naisjob_doc_example.go
+++ b/pkg/apis/nais.io/v1/naisjob_doc_example.go
@@ -112,9 +112,7 @@ func ExampleNaisjobForDocumentation() *Naisjob {
 							Host: "non-http-service.example.com",
 							Ports: []AccessPolicyPortRule{
 								{
-									Name:     "kafka",
-									Port:     9200,
-									Protocol: "TCP",
+									Port: 9200,
 								},
 							},
 						},

--- a/pkg/apis/nais.io/v1alpha1/application_doc_example.go
+++ b/pkg/apis/nais.io/v1alpha1/application_doc_example.go
@@ -114,9 +114,7 @@ func ExampleApplicationForDocumentation() *Application {
 							Host: "non-http-service.example.com",
 							Ports: []nais_io_v1.AccessPolicyPortRule{
 								{
-									Name:     "kafka",
-									Port:     9200,
-									Protocol: "TCP",
+									Port: 9200,
 								},
 							},
 						},
@@ -151,8 +149,7 @@ func ExampleApplicationForDocumentation() *Application {
 							"/path",
 							"/internal/*",
 						},
-						Enabled:   true,
-						ErrorPath: "/error",
+						Enabled: true,
 						Resources: &nais_io_v1.ResourceRequirements{
 							Limits: &nais_io_v1.ResourceSpec{
 								Cpu:    "250m",
@@ -317,8 +314,7 @@ func ExampleApplicationForDocumentation() *Application {
 							"/path",
 							"/internal/*",
 						},
-						Enabled:   true,
-						ErrorPath: "/error",
+						Enabled: true,
 						Resources: &nais_io_v1.ResourceRequirements{
 							Limits: &nais_io_v1.ResourceSpec{
 								Cpu:    "250m",


### PR DESCRIPTION
These aren't used in naiserator anymore, so we should remove them (especially from the autogenerated reference/example documentation): 

- `external.port.name` and `external.port.protocol` are remnants from Istio ServiceEntry resources
- `sidecar.errorPath` is obsolete