### PR TITLE
fix: dns validering for accesspolicy.host

### DIFF
--- a/charts/templates/nais.io_applications.yaml
+++ b/charts/templates/nais.io_applications.yaml
@@ -115,6 +115,7 @@ spec:
                               description: The _host_ that your application should
                                 be able to reach, i.e. without the protocol (e.g.
                                 `https://`).
+                              pattern: (?=^.{4,253}$)(^((?!-)[a-zA-Z0-9-]{0,62}[a-zA-Z0-9]\.)+[a-zA-Z]{2,63}$)
                               type: string
                             ports:
                               description: List of port rules for external communication.

--- a/charts/templates/nais.io_jwkers.yaml
+++ b/charts/templates/nais.io_jwkers.yaml
@@ -101,6 +101,7 @@ spec:
                               description: The _host_ that your application should
                                 be able to reach, i.e. without the protocol (e.g.
                                 `https://`).
+                              pattern: (?=^.{4,253}$)(^((?!-)[a-zA-Z0-9-]{0,62}[a-zA-Z0-9]\.)+[a-zA-Z]{2,63}$)
                               type: string
                             ports:
                               description: List of port rules for external communication.

--- a/charts/templates/nais.io_naisjobs.yaml
+++ b/charts/templates/nais.io_naisjobs.yaml
@@ -118,6 +118,7 @@ spec:
                               description: The _host_ that your application should
                                 be able to reach, i.e. without the protocol (e.g.
                                 `https://`).
+                              pattern: (?=^.{4,253}$)(^((?!-)[a-zA-Z0-9-]{0,62}[a-zA-Z0-9]\.)+[a-zA-Z]{2,63}$)
                               type: string
                             ports:
                               description: List of port rules for external communication.

--- a/config/crd/bases/nais.io_applications.yaml
+++ b/config/crd/bases/nais.io_applications.yaml
@@ -115,6 +115,7 @@ spec:
                               description: The _host_ that your application should
                                 be able to reach, i.e. without the protocol (e.g.
                                 `https://`).
+                              pattern: (?=^.{4,253}$)(^((?!-)[a-zA-Z0-9-]{0,62}[a-zA-Z0-9]\.)+[a-zA-Z]{2,63}$)
                               type: string
                             ports:
                               description: List of port rules for external communication.

--- a/config/crd/bases/nais.io_jwkers.yaml
+++ b/config/crd/bases/nais.io_jwkers.yaml
@@ -101,6 +101,7 @@ spec:
                               description: The _host_ that your application should
                                 be able to reach, i.e. without the protocol (e.g.
                                 `https://`).
+                              pattern: (?=^.{4,253}$)(^((?!-)[a-zA-Z0-9-]{0,62}[a-zA-Z0-9]\.)+[a-zA-Z]{2,63}$)
                               type: string
                             ports:
                               description: List of port rules for external communication.

--- a/config/crd/bases/nais.io_naisjobs.yaml
+++ b/config/crd/bases/nais.io_naisjobs.yaml
@@ -118,6 +118,7 @@ spec:
                               description: The _host_ that your application should
                                 be able to reach, i.e. without the protocol (e.g.
                                 `https://`).
+                              pattern: (?=^.{4,253}$)(^((?!-)[a-zA-Z0-9-]{0,62}[a-zA-Z0-9]\.)+[a-zA-Z]{2,63}$)
                               type: string
                             ports:
                               description: List of port rules for external communication.

--- a/pkg/apis/nais.io/v1/accesspolicy.go
+++ b/pkg/apis/nais.io/v1/accesspolicy.go
@@ -7,6 +7,7 @@ type AccessPolicyPortRule struct {
 
 type AccessPolicyExternalRule struct {
 	// The _host_ that your application should be able to reach, i.e. without the protocol (e.g. `https://`).
+	// +kubebuilder:validation:Pattern=`(?=^.{4,253}$)(^((?!-)[a-zA-Z0-9-]{0,62}[a-zA-Z0-9]\.)+[a-zA-Z]{2,63}$)`
 	Host string `json:"host"`
 	// List of port rules for external communication. Must be specified if using protocols other than HTTPS.
 	Ports []AccessPolicyPortRule `json:"ports,omitempty"`


### PR DESCRIPTION
https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names https://www.regextester.com/103452

Vet ikke om det er behov for å validere port? Per nå kan man skrive hva man vil.