### PR TITLE
fix: forenklet rfc1123 regex

### DIFF
--- a/charts/templates/nais.io_applications.yaml
+++ b/charts/templates/nais.io_applications.yaml
@@ -113,7 +113,7 @@ spec:
                               description: The _host_ that your application should
                                 be able to reach, i.e. without the protocol (e.g.
                                 `https://`).
-                              pattern: (?=^.{4,253}$)(^((?!-)[a-zA-Z0-9-]{0,62}[a-zA-Z0-9]\.)+[a-zA-Z]{2,63}$)
+                              pattern: ^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])(\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9]))*$
                               type: string
                             ports:
                               description: List of port rules for external communication.

--- a/charts/templates/nais.io_jwkers.yaml
+++ b/charts/templates/nais.io_jwkers.yaml
@@ -99,7 +99,7 @@ spec:
                               description: The _host_ that your application should
                                 be able to reach, i.e. without the protocol (e.g.
                                 `https://`).
-                              pattern: (?=^.{4,253}$)(^((?!-)[a-zA-Z0-9-]{0,62}[a-zA-Z0-9]\.)+[a-zA-Z]{2,63}$)
+                              pattern: ^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])(\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9]))*$
                               type: string
                             ports:
                               description: List of port rules for external communication.

--- a/charts/templates/nais.io_naisjobs.yaml
+++ b/charts/templates/nais.io_naisjobs.yaml
@@ -116,7 +116,7 @@ spec:
                               description: The _host_ that your application should
                                 be able to reach, i.e. without the protocol (e.g.
                                 `https://`).
-                              pattern: (?=^.{4,253}$)(^((?!-)[a-zA-Z0-9-]{0,62}[a-zA-Z0-9]\.)+[a-zA-Z]{2,63}$)
+                              pattern: ^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])(\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9]))*$
                               type: string
                             ports:
                               description: List of port rules for external communication.

--- a/config/crd/bases/nais.io_applications.yaml
+++ b/config/crd/bases/nais.io_applications.yaml
@@ -113,7 +113,7 @@ spec:
                               description: The _host_ that your application should
                                 be able to reach, i.e. without the protocol (e.g.
                                 `https://`).
-                              pattern: (?=^.{4,253}$)(^((?!-)[a-zA-Z0-9-]{0,62}[a-zA-Z0-9]\.)+[a-zA-Z]{2,63}$)
+                              pattern: ^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])(\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9]))*$
                               type: string
                             ports:
                               description: List of port rules for external communication.

--- a/config/crd/bases/nais.io_jwkers.yaml
+++ b/config/crd/bases/nais.io_jwkers.yaml
@@ -99,7 +99,7 @@ spec:
                               description: The _host_ that your application should
                                 be able to reach, i.e. without the protocol (e.g.
                                 `https://`).
-                              pattern: (?=^.{4,253}$)(^((?!-)[a-zA-Z0-9-]{0,62}[a-zA-Z0-9]\.)+[a-zA-Z]{2,63}$)
+                              pattern: ^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])(\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9]))*$
                               type: string
                             ports:
                               description: List of port rules for external communication.

--- a/config/crd/bases/nais.io_naisjobs.yaml
+++ b/config/crd/bases/nais.io_naisjobs.yaml
@@ -116,7 +116,7 @@ spec:
                               description: The _host_ that your application should
                                 be able to reach, i.e. without the protocol (e.g.
                                 `https://`).
-                              pattern: (?=^.{4,253}$)(^((?!-)[a-zA-Z0-9-]{0,62}[a-zA-Z0-9]\.)+[a-zA-Z]{2,63}$)
+                              pattern: ^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])(\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9]))*$
                               type: string
                             ports:
                               description: List of port rules for external communication.

--- a/pkg/apis/nais.io/v1/accesspolicy.go
+++ b/pkg/apis/nais.io/v1/accesspolicy.go
@@ -7,7 +7,7 @@ type AccessPolicyPortRule struct {
 
 type AccessPolicyExternalRule struct {
 	// The _host_ that your application should be able to reach, i.e. without the protocol (e.g. `https://`).
-	// +kubebuilder:validation:Pattern=`(?=^.{4,253}$)(^((?!-)[a-zA-Z0-9-]{0,62}[a-zA-Z0-9]\.)+[a-zA-Z]{2,63}$)`
+	// +kubebuilder:validation:Pattern=`^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])(\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9]))*$`
 	Host string `json:"host"`
 	// List of port rules for external communication. Must be specified if using protocols other than HTTPS.
 	Ports []AccessPolicyPortRule `json:"ports,omitempty"`


### PR DESCRIPTION
Golang støtter ikke negativ lookahead, så bruker en enklere regex for hostname.
Denne støtter ikke IP-er, så satser på at folk ikke trenger det.