### PR TITLE
Add integration name to IDPortenClientSpec and MaskinportenClientSpec

### DIFF
--- a/charts/templates/aiven.nais.io_aivenapplications.yaml
+++ b/charts/templates/aiven.nais.io_aivenapplications.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.12.1
   name: aivenapplications.aiven.nais.io
 spec:
   group: aiven.nais.io

--- a/charts/templates/google.nais.io_bigquerydatasets.yaml
+++ b/charts/templates/google.nais.io_bigquerydatasets.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.12.1
   name: bigquerydatasets.google.nais.io
 spec:
   group: google.nais.io

--- a/charts/templates/kafka.nais.io_streams.yaml
+++ b/charts/templates/kafka.nais.io_streams.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.12.1
   name: streams.kafka.nais.io
 spec:
   group: kafka.nais.io

--- a/charts/templates/kafka.nais.io_topics.yaml
+++ b/charts/templates/kafka.nais.io_topics.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.12.1
   name: topics.kafka.nais.io
 spec:
   group: kafka.nais.io

--- a/charts/templates/nais.io_applications.yaml
+++ b/charts/templates/nais.io_applications.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.12.1
   name: applications.nais.io
 spec:
   group: nais.io

--- a/charts/templates/nais.io_azureadapplications.yaml
+++ b/charts/templates/nais.io_azureadapplications.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.12.1
   name: azureadapplications.nais.io
 spec:
   group: nais.io

--- a/charts/templates/nais.io_idportenclients.yaml
+++ b/charts/templates/nais.io_idportenclients.yaml
@@ -58,6 +58,12 @@ spec:
                 maximum: 3600
                 minimum: 1
                 type: integer
+              clientName:
+                description: ClientName is the client name to be registered at DigDir.
+                  It is shown during login for user-centric flows, and is otherwise
+                  a human-readable way to differentiate between clients at DigDir's
+                  self-service portal.
+                type: string
               clientURI:
                 description: ClientURI is the URL to the client to be used at DigDir
                   when displaying a 'back' button or on errors
@@ -68,9 +74,6 @@ spec:
                   a requests to whenever a logout is triggered by another application
                   using the same session
                 pattern: ^https:\/\/.+$
-                type: string
-              integrationName:
-                description: Name of integration
                 type: string
               integrationType:
                 description: "IntegrationType is used to make sensible choices for

--- a/charts/templates/nais.io_idportenclients.yaml
+++ b/charts/templates/nais.io_idportenclients.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.12.1
   name: idportenclients.nais.io
 spec:
   group: nais.io
@@ -68,6 +68,9 @@ spec:
                   a requests to whenever a logout is triggered by another application
                   using the same session
                 pattern: ^https:\/\/.+$
+                type: string
+              integrationName:
+                description: Name of integration
                 type: string
               integrationType:
                 description: "IntegrationType is used to make sensible choices for

--- a/charts/templates/nais.io_jwkers.yaml
+++ b/charts/templates/nais.io_jwkers.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.12.1
   name: jwkers.nais.io
 spec:
   group: nais.io

--- a/charts/templates/nais.io_maskinportenclients.yaml
+++ b/charts/templates/nais.io_maskinportenclients.yaml
@@ -52,7 +52,11 @@ spec:
           spec:
             description: MaskinportenClientSpec defines the desired state of MaskinportenClient
             properties:
-              integrationName:
+              clientName:
+                description: ClientName is the client name to be registered at DigDir.
+                  It is shown during login for user-centric flows, and is otherwise
+                  a human-readable way to differentiate between clients at DigDir's
+                  self-service portal.
                 type: string
               scopes:
                 description: Scopes is a object of used end exposed scopes by application

--- a/charts/templates/nais.io_maskinportenclients.yaml
+++ b/charts/templates/nais.io_maskinportenclients.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.12.1
   name: maskinportenclients.nais.io
 spec:
   group: nais.io
@@ -52,6 +52,8 @@ spec:
           spec:
             description: MaskinportenClientSpec defines the desired state of MaskinportenClient
             properties:
+              integrationName:
+                type: string
               scopes:
                 description: Scopes is a object of used end exposed scopes by application
                 properties:

--- a/charts/templates/nais.io_naisjobs.yaml
+++ b/charts/templates/nais.io_naisjobs.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.12.1
   name: naisjobs.nais.io
 spec:
   group: nais.io

--- a/config/crd/bases/aiven.nais.io_aivenapplications.yaml
+++ b/config/crd/bases/aiven.nais.io_aivenapplications.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.12.1
   name: aivenapplications.aiven.nais.io
 spec:
   group: aiven.nais.io

--- a/config/crd/bases/bigquery.cnrm.cloud.google.com_bigquerydatasets.yaml
+++ b/config/crd/bases/bigquery.cnrm.cloud.google.com_bigquerydatasets.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.12.1
   name: bigquerydatasets.bigquery.cnrm.cloud.google.com
 spec:
   group: bigquery.cnrm.cloud.google.com

--- a/config/crd/bases/google.nais.io_bigquerydatasets.yaml
+++ b/config/crd/bases/google.nais.io_bigquerydatasets.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.12.1
   name: bigquerydatasets.google.nais.io
 spec:
   group: google.nais.io

--- a/config/crd/bases/iam.cnrm.cloud.google.com_iampolicies.yaml
+++ b/config/crd/bases/iam.cnrm.cloud.google.com_iampolicies.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.12.1
   name: iampolicies.iam.cnrm.cloud.google.com
 spec:
   group: iam.cnrm.cloud.google.com

--- a/config/crd/bases/iam.cnrm.cloud.google.com_iampolicymembers.yaml
+++ b/config/crd/bases/iam.cnrm.cloud.google.com_iampolicymembers.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.12.1
   name: iampolicymembers.iam.cnrm.cloud.google.com
 spec:
   group: iam.cnrm.cloud.google.com

--- a/config/crd/bases/iam.cnrm.cloud.google.com_iamserviceaccounts.yaml
+++ b/config/crd/bases/iam.cnrm.cloud.google.com_iamserviceaccounts.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.12.1
   name: iamserviceaccounts.iam.cnrm.cloud.google.com
 spec:
   group: iam.cnrm.cloud.google.com

--- a/config/crd/bases/kafka.nais.io_streams.yaml
+++ b/config/crd/bases/kafka.nais.io_streams.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.12.1
   name: streams.kafka.nais.io
 spec:
   group: kafka.nais.io

--- a/config/crd/bases/kafka.nais.io_topics.yaml
+++ b/config/crd/bases/kafka.nais.io_topics.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.12.1
   name: topics.kafka.nais.io
 spec:
   group: kafka.nais.io

--- a/config/crd/bases/nais.io_applications.yaml
+++ b/config/crd/bases/nais.io_applications.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.12.1
   name: applications.nais.io
 spec:
   group: nais.io

--- a/config/crd/bases/nais.io_azureadapplications.yaml
+++ b/config/crd/bases/nais.io_azureadapplications.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.12.1
   name: azureadapplications.nais.io
 spec:
   group: nais.io

--- a/config/crd/bases/nais.io_idportenclients.yaml
+++ b/config/crd/bases/nais.io_idportenclients.yaml
@@ -58,6 +58,12 @@ spec:
                 maximum: 3600
                 minimum: 1
                 type: integer
+              clientName:
+                description: ClientName is the client name to be registered at DigDir.
+                  It is shown during login for user-centric flows, and is otherwise
+                  a human-readable way to differentiate between clients at DigDir's
+                  self-service portal.
+                type: string
               clientURI:
                 description: ClientURI is the URL to the client to be used at DigDir
                   when displaying a 'back' button or on errors
@@ -68,9 +74,6 @@ spec:
                   a requests to whenever a logout is triggered by another application
                   using the same session
                 pattern: ^https:\/\/.+$
-                type: string
-              integrationName:
-                description: Name of integration
                 type: string
               integrationType:
                 description: "IntegrationType is used to make sensible choices for

--- a/config/crd/bases/nais.io_idportenclients.yaml
+++ b/config/crd/bases/nais.io_idportenclients.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.12.1
   name: idportenclients.nais.io
 spec:
   group: nais.io
@@ -68,6 +68,9 @@ spec:
                   a requests to whenever a logout is triggered by another application
                   using the same session
                 pattern: ^https:\/\/.+$
+                type: string
+              integrationName:
+                description: Name of integration
                 type: string
               integrationType:
                 description: "IntegrationType is used to make sensible choices for

--- a/config/crd/bases/nais.io_jwkers.yaml
+++ b/config/crd/bases/nais.io_jwkers.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.12.1
   name: jwkers.nais.io
 spec:
   group: nais.io

--- a/config/crd/bases/nais.io_maskinportenclients.yaml
+++ b/config/crd/bases/nais.io_maskinportenclients.yaml
@@ -52,7 +52,11 @@ spec:
           spec:
             description: MaskinportenClientSpec defines the desired state of MaskinportenClient
             properties:
-              integrationName:
+              clientName:
+                description: ClientName is the client name to be registered at DigDir.
+                  It is shown during login for user-centric flows, and is otherwise
+                  a human-readable way to differentiate between clients at DigDir's
+                  self-service portal.
                 type: string
               scopes:
                 description: Scopes is a object of used end exposed scopes by application

--- a/config/crd/bases/nais.io_maskinportenclients.yaml
+++ b/config/crd/bases/nais.io_maskinportenclients.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.12.1
   name: maskinportenclients.nais.io
 spec:
   group: nais.io
@@ -52,6 +52,8 @@ spec:
           spec:
             description: MaskinportenClientSpec defines the desired state of MaskinportenClient
             properties:
+              integrationName:
+                type: string
               scopes:
                 description: Scopes is a object of used end exposed scopes by application
                 properties:

--- a/config/crd/bases/nais.io_naisjobs.yaml
+++ b/config/crd/bases/nais.io_naisjobs.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.12.1
   name: naisjobs.nais.io
 spec:
   group: nais.io

--- a/config/crd/bases/sql.cnrm.cloud.google.com_sqldatabases.yaml
+++ b/config/crd/bases/sql.cnrm.cloud.google.com_sqldatabases.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.12.1
   name: sqldatabases.sql.cnrm.cloud.google.com
 spec:
   group: sql.cnrm.cloud.google.com

--- a/config/crd/bases/sql.cnrm.cloud.google.com_sqlinstances.yaml
+++ b/config/crd/bases/sql.cnrm.cloud.google.com_sqlinstances.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.12.1
   name: sqlinstances.sql.cnrm.cloud.google.com
 spec:
   group: sql.cnrm.cloud.google.com

--- a/config/crd/bases/sql.cnrm.cloud.google.com_sqlusers.yaml
+++ b/config/crd/bases/sql.cnrm.cloud.google.com_sqlusers.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.12.1
   name: sqlusers.sql.cnrm.cloud.google.com
 spec:
   group: sql.cnrm.cloud.google.com

--- a/config/crd/bases/storage.cnrm.cloud.google.com_storagebucketaccesscontrols.yaml
+++ b/config/crd/bases/storage.cnrm.cloud.google.com_storagebucketaccesscontrols.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.12.1
   name: storagebucketaccesscontrols.storage.cnrm.cloud.google.com
 spec:
   group: storage.cnrm.cloud.google.com

--- a/config/crd/bases/storage.cnrm.cloud.google.com_storagebuckets.yaml
+++ b/config/crd/bases/storage.cnrm.cloud.google.com_storagebuckets.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.12.1
   name: storagebuckets.storage.cnrm.cloud.google.com
 spec:
   group: storage.cnrm.cloud.google.com

--- a/pkg/apis/nais.io/v1/digdirator_types.go
+++ b/pkg/apis/nais.io/v1/digdirator_types.go
@@ -100,7 +100,9 @@ type MaskinportenClient struct {
 
 // MaskinportenClientSpec defines the desired state of MaskinportenClient
 type MaskinportenClientSpec struct {
-	IntegrationName string `json:"integrationName,omitempty"`
+	// ClientName is the client name to be registered at DigDir.
+	// It is shown during login for user-centric flows, and is otherwise a human-readable way to differentiate between clients at DigDir's self-service portal.
+	ClientName string `json:"clientName,omitempty"`
 	// Scopes is a object of used end exposed scopes by application
 	Scopes MaskinportenScope `json:"scopes,omitempty"`
 	// SecretName is the name of the resulting Secret resource to be created
@@ -244,8 +246,9 @@ type IDPortenClientSpec struct {
 	AccessTokenLifetime *int `json:"accessTokenLifetime,omitempty"`
 	// ClientURI is the URL to the client to be used at DigDir when displaying a 'back' button or on errors
 	ClientURI IDPortenURI `json:"clientURI,omitempty"`
-	// Name of integration
-	IntegrationName string `json:"integrationName,omitempty"`
+	// ClientName is the client name to be registered at DigDir.
+	// It is shown during login for user-centric flows, and is otherwise a human-readable way to differentiate between clients at DigDir's self-service portal.
+	ClientName string `json:"clientName,omitempty"`
 	// IntegrationType is used to make sensible choices for your client.
 	// Which type of integration you choose will provide guidance on which scopes you can use with the client.
 	// A client can only have one integration type.

--- a/pkg/apis/nais.io/v1/digdirator_types.go
+++ b/pkg/apis/nais.io/v1/digdirator_types.go
@@ -100,6 +100,7 @@ type MaskinportenClient struct {
 
 // MaskinportenClientSpec defines the desired state of MaskinportenClient
 type MaskinportenClientSpec struct {
+	IntegrationName string `json:"integrationName,omitempty"`
 	// Scopes is a object of used end exposed scopes by application
 	Scopes MaskinportenScope `json:"scopes,omitempty"`
 	// SecretName is the name of the resulting Secret resource to be created
@@ -243,6 +244,8 @@ type IDPortenClientSpec struct {
 	AccessTokenLifetime *int `json:"accessTokenLifetime,omitempty"`
 	// ClientURI is the URL to the client to be used at DigDir when displaying a 'back' button or on errors
 	ClientURI IDPortenURI `json:"clientURI,omitempty"`
+	// Name of integration
+	IntegrationName string `json:"integrationName,omitempty"`
 	// IntegrationType is used to make sensible choices for your client.
 	// Which type of integration you choose will provide guidance on which scopes you can use with the client.
 	// A client can only have one integration type.


### PR DESCRIPTION
Update idporten and maskinporten CRDs to include field for integration name. 
Will help differentiate between integrations when looking through samarbeidsportalen. 

Requires changes in digdirator: https://github.com/nais/digdirator/pull/201