### PR TITLE
Add support for timezone definition on NaisJob

### DIFF
--- a/charts/templates/nais.io_naisjobs.yaml
+++ b/charts/templates/nais.io_naisjobs.yaml
@@ -1076,6 +1076,10 @@ spec:
                 maximum: 180
                 minimum: 0
                 type: integer
+              timezone:
+                description: TimeZone for Naisjobs. Defaults to UTC. Only used if
+                  Schedule is specified. Specify a valid [IANA timezone](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones).
+                type: string
               ttlSecondsAfterFinished:
                 description: Specify the number of seconds to wait before removing
                   the Job after it has finished (either Completed or Failed). If the

--- a/charts/templates/nais.io_naisjobs.yaml
+++ b/charts/templates/nais.io_naisjobs.yaml
@@ -1076,7 +1076,7 @@ spec:
                 maximum: 180
                 minimum: 0
                 type: integer
-              timezone:
+              timeZone:
                 description: TimeZone for Naisjobs. Defaults to UTC. Only used if
                   Schedule is specified. Specify a valid [IANA timezone](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones).
                 type: string

--- a/config/crd/bases/nais.io_naisjobs.yaml
+++ b/config/crd/bases/nais.io_naisjobs.yaml
@@ -1076,6 +1076,10 @@ spec:
                 maximum: 180
                 minimum: 0
                 type: integer
+              timezone:
+                description: TimeZone for Naisjobs. Defaults to UTC. Only used if
+                  Schedule is specified. Specify a valid [IANA timezone](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones).
+                type: string
               ttlSecondsAfterFinished:
                 description: Specify the number of seconds to wait before removing
                   the Job after it has finished (either Completed or Failed). If the

--- a/config/crd/bases/nais.io_naisjobs.yaml
+++ b/config/crd/bases/nais.io_naisjobs.yaml
@@ -1076,7 +1076,7 @@ spec:
                 maximum: 180
                 minimum: 0
                 type: integer
-              timezone:
+              timeZone:
                 description: TimeZone for Naisjobs. Defaults to UTC. Only used if
                   Schedule is specified. Specify a valid [IANA timezone](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones).
                 type: string

--- a/pkg/apis/nais.io/v1/naisjob_doc_example.go
+++ b/pkg/apis/nais.io/v1/naisjob_doc_example.go
@@ -17,6 +17,9 @@ func ExampleNaisjobForDocumentation() *Naisjob {
 	boolp := func(b bool) *bool {
 		return &b
 	}
+	stringp := func(s string) *string {
+		return &s
+	}
 
 	return &Naisjob{
 		TypeMeta: metav1.TypeMeta{
@@ -362,6 +365,7 @@ func ExampleNaisjobForDocumentation() *Naisjob {
 			},
 			SuccessfulJobsHistoryLimit:    2,
 			TerminationGracePeriodSeconds: int64p(60),
+			TimeZone:                      stringp("Europe/Oslo"),
 			TTLSecondsAfterFinished:       int32p(60),
 			Vault: &Vault{
 				Enabled: true,

--- a/pkg/apis/nais.io/v1/naisjob_types.go
+++ b/pkg/apis/nais.io/v1/naisjob_types.go
@@ -199,7 +199,7 @@ type NaisjobSpec struct {
 
 	// TimeZone for Naisjobs. Defaults to UTC. Only used if Schedule is specified.
 	// Specify a valid [IANA timezone](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones).
-	TimeZone *string `json:"timezone,omitempty"`
+	TimeZone *string `json:"timeZone,omitempty"`
 
 	// Specify the number of seconds to wait before removing the Job after it has finished (either Completed or Failed).
 	// If the field is unset, this Job won't be cleaned up by the TTL controller after it finishes.

--- a/pkg/apis/nais.io/v1/naisjob_types.go
+++ b/pkg/apis/nais.io/v1/naisjob_types.go
@@ -197,6 +197,10 @@ type NaisjobSpec struct {
 	// +kubebuilder:validation:Maximum=180
 	TerminationGracePeriodSeconds *int64 `json:"terminationGracePeriodSeconds,omitempty"`
 
+	// TimeZone for Naisjobs. Defaults to UTC. Only used if Schedule is specified.
+	// Specify a valid [IANA timezone](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones).
+	TimeZone *string `json:"timezone,omitempty"`
+
 	// Specify the number of seconds to wait before removing the Job after it has finished (either Completed or Failed).
 	// If the field is unset, this Job won't be cleaned up by the TTL controller after it finishes.
 	TTLSecondsAfterFinished *int32 `json:"ttlSecondsAfterFinished,omitempty"`

--- a/pkg/apis/nais.io/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/nais.io/v1/zz_generated.deepcopy.go
@@ -1670,6 +1670,11 @@ func (in *NaisjobSpec) DeepCopyInto(out *NaisjobSpec) {
 		*out = new(int64)
 		**out = **in
 	}
+	if in.TimeZone != nil {
+		in, out := &in.TimeZone, &out.TimeZone
+		*out = new(string)
+		**out = **in
+	}
 	if in.TTLSecondsAfterFinished != nil {
 		in, out := &in.TTLSecondsAfterFinished, &out.TTLSecondsAfterFinished
 		*out = new(int32)


### PR DESCRIPTION
This feature became stable in kubernetes 1.27 https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#time-zones