### PR TITLE
Allow HTTP (localhost only) for IDPortenUri

### DIFF
--- a/pkg/apis/nais.io/v1/digdirator_types.go
+++ b/pkg/apis/nais.io/v1/digdirator_types.go
@@ -293,7 +293,7 @@ type IDPortenClientSpec struct {
 	SSODisabled *bool `json:"ssoDisabled,omitempty"`
 }
 
-// +kubebuilder:validation:Pattern=`^https:\/\/.+$`
+// +kubebuilder:validation:Pattern=`^(https:\/\/)|(http:\/\/localhost\:).+$`
 type IDPortenURI string
 
 func (in *IDPortenClient) Hash() (string, error) {


### PR DESCRIPTION
As discussed on the OPaaS-slack.

For local development it can be nice to allow http as a URL to ID-porten (for things like post-login-uri etc). But since the general rule should be to only use HTTPS, this pattern will only allow HTTP if it is on localhost. This means we would not need to use self-signed certificate to do local development with authentication enabled.

DigDir does not allow `http` in production, but for test-clients it is allowed.

This pattern will match URIs that either start with `https://` or `http://localhost:` (i added the requirement to add `:` which is usually followed by a port to make sure it did not match domains that just start with the word `localhost` like "localhost.com")

```
http://localhost:8080/
https://kartverket.no
https://nav.no
```

It will not match URIs like:
```
http://localhost.com
http://kartverket.no
http://nav.no
```