### PR TITLE
maskinporten: add validation rule for exposed scopes

### DIFF
--- a/charts/templates/nais.io_applications.yaml
+++ b/charts/templates/nais.io_applications.yaml
@@ -1019,6 +1019,11 @@ spec:
                           - name
                           - product
                           type: object
+                          x-kubernetes-validations:
+                          - message: scopes.exposes[].separator must be set to "/"
+                              when scopes.exposes[].delegationSource is set
+                            rule: '!has(self.delegationSource) || (has(self.separator)
+                              && self.separator == "/")'
                         type: array
                     type: object
                 required:

--- a/charts/templates/nais.io_maskinportenclients.yaml
+++ b/charts/templates/nais.io_maskinportenclients.yaml
@@ -158,6 +158,11 @@ spec:
                       - name
                       - product
                       type: object
+                      x-kubernetes-validations:
+                      - message: scopes.exposes[].separator must be set to "/" when
+                          scopes.exposes[].delegationSource is set
+                        rule: '!has(self.delegationSource) || (has(self.separator)
+                          && self.separator == "/")'
                     type: array
                 type: object
               secretName:

--- a/charts/templates/nais.io_naisjobs.yaml
+++ b/charts/templates/nais.io_naisjobs.yaml
@@ -887,6 +887,11 @@ spec:
                           - name
                           - product
                           type: object
+                          x-kubernetes-validations:
+                          - message: scopes.exposes[].separator must be set to "/"
+                              when scopes.exposes[].delegationSource is set
+                            rule: '!has(self.delegationSource) || (has(self.separator)
+                              && self.separator == "/")'
                         type: array
                     type: object
                 required:

--- a/config/crd/bases/nais.io_applications.yaml
+++ b/config/crd/bases/nais.io_applications.yaml
@@ -1019,6 +1019,11 @@ spec:
                           - name
                           - product
                           type: object
+                          x-kubernetes-validations:
+                          - message: scopes.exposes[].separator must be set to "/"
+                              when scopes.exposes[].delegationSource is set
+                            rule: '!has(self.delegationSource) || (has(self.separator)
+                              && self.separator == "/")'
                         type: array
                     type: object
                 required:

--- a/config/crd/bases/nais.io_maskinportenclients.yaml
+++ b/config/crd/bases/nais.io_maskinportenclients.yaml
@@ -158,6 +158,11 @@ spec:
                       - name
                       - product
                       type: object
+                      x-kubernetes-validations:
+                      - message: scopes.exposes[].separator must be set to "/" when
+                          scopes.exposes[].delegationSource is set
+                        rule: '!has(self.delegationSource) || (has(self.separator)
+                          && self.separator == "/")'
                     type: array
                 type: object
               secretName:

--- a/config/crd/bases/nais.io_naisjobs.yaml
+++ b/config/crd/bases/nais.io_naisjobs.yaml
@@ -887,6 +887,11 @@ spec:
                           - name
                           - product
                           type: object
+                          x-kubernetes-validations:
+                          - message: scopes.exposes[].separator must be set to "/"
+                              when scopes.exposes[].delegationSource is set
+                            rule: '!has(self.delegationSource) || (has(self.separator)
+                              && self.separator == "/")'
                         type: array
                     type: object
                 required:

--- a/pkg/apis/nais.io/v1/digdirator_types.go
+++ b/pkg/apis/nais.io/v1/digdirator_types.go
@@ -134,6 +134,7 @@ type ConsumedScope struct {
 	Name string `json:"name"`
 }
 
+// +kubebuilder:validation:XValidation:rule="!has(self.delegationSource) || (has(self.separator) && self.separator == \"/\")",message="scopes.exposes[].separator must be set to \"/\" when scopes.exposes[].delegationSource is set"
 type ExposedScope struct {
 	// If Enabled the configured scope is available to be used and consumed by organizations granted access.
 	// +kubebuilder:validation:Required


### PR DESCRIPTION
The `delegationSource` field for exposed scopes is optional. However if `delegationSource` is set, the separator field must accordingly be set to `"/"` due to some arcane validation logic in Altinn (see previous PR: https://github.com/nais/liberator/pull/214)

This adds a CEL validation rule to the CRD schema that enforces this logic.

See also:
- https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#validation-rules
- https://kubernetes.io/docs/reference/access-authn-authz/validating-admission-policy/#optional-parameters