### PR TITLE
digdirator: add status fields for ObservedGeneration and Conditions

### DIFF
--- a/charts/templates/nais.io_idportenclients.yaml
+++ b/charts/templates/nais.io_idportenclients.yaml
@@ -151,6 +151,77 @@ spec:
                 description: ClientID is the corresponding client ID for this client
                   at Digdir
                 type: string
+              conditions:
+                description: Conditions is the list of details for the current state
+                  of this API Resource.
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
               correlationID:
                 description: CorrelationID is the ID referencing the processing transaction
                   last performed on this resource
@@ -161,6 +232,11 @@ spec:
                 items:
                   type: string
                 type: array
+              observedGeneration:
+                description: ObservedGeneration is the generation most recently observed
+                  by Digdirator.
+                format: int64
+                type: integer
               synchronizationHash:
                 description: SynchronizationHash is the hash of the Instance object
                 type: string

--- a/charts/templates/nais.io_maskinportenclients.yaml
+++ b/charts/templates/nais.io_maskinportenclients.yaml
@@ -179,6 +179,77 @@ spec:
                 description: ClientID is the corresponding client ID for this client
                   at Digdir
                 type: string
+              conditions:
+                description: Conditions is the list of details for the current state
+                  of this API Resource.
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
               correlationID:
                 description: CorrelationID is the ID referencing the processing transaction
                   last performed on this resource
@@ -189,6 +260,11 @@ spec:
                 items:
                   type: string
                 type: array
+              observedGeneration:
+                description: ObservedGeneration is the generation most recently observed
+                  by Digdirator.
+                format: int64
+                type: integer
               synchronizationHash:
                 description: SynchronizationHash is the hash of the Instance object
                 type: string

--- a/config/crd/bases/nais.io_idportenclients.yaml
+++ b/config/crd/bases/nais.io_idportenclients.yaml
@@ -151,6 +151,77 @@ spec:
                 description: ClientID is the corresponding client ID for this client
                   at Digdir
                 type: string
+              conditions:
+                description: Conditions is the list of details for the current state
+                  of this API Resource.
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
               correlationID:
                 description: CorrelationID is the ID referencing the processing transaction
                   last performed on this resource
@@ -161,6 +232,11 @@ spec:
                 items:
                   type: string
                 type: array
+              observedGeneration:
+                description: ObservedGeneration is the generation most recently observed
+                  by Digdirator.
+                format: int64
+                type: integer
               synchronizationHash:
                 description: SynchronizationHash is the hash of the Instance object
                 type: string

--- a/config/crd/bases/nais.io_maskinportenclients.yaml
+++ b/config/crd/bases/nais.io_maskinportenclients.yaml
@@ -179,6 +179,77 @@ spec:
                 description: ClientID is the corresponding client ID for this client
                   at Digdir
                 type: string
+              conditions:
+                description: Conditions is the list of details for the current state
+                  of this API Resource.
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
               correlationID:
                 description: CorrelationID is the ID referencing the processing transaction
                   last performed on this resource
@@ -189,6 +260,11 @@ spec:
                 items:
                   type: string
                 type: array
+              observedGeneration:
+                description: ObservedGeneration is the generation most recently observed
+                  by Digdirator.
+                format: int64
+                type: integer
               synchronizationHash:
                 description: SynchronizationHash is the hash of the Instance object
                 type: string

--- a/pkg/apis/nais.io/v1/digdirator_types.go
+++ b/pkg/apis/nais.io/v1/digdirator_types.go
@@ -1,6 +1,7 @@
 package nais_io_v1
 
 import (
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/nais/liberator/pkg/events"
@@ -23,52 +24,28 @@ type DigdiratorStatus struct {
 	CorrelationID string `json:"correlationID,omitempty"`
 	// KeyIDs is the list of key IDs for valid JWKs registered for the client at Digdir
 	KeyIDs []string `json:"keyIDs,omitempty"`
+	// ObservedGeneration is the generation most recently observed by Digdirator.
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
+	// Conditions is the list of details for the current state of this API Resource.
+	Conditions *[]metav1.Condition `json:"conditions,omitempty"`
 }
 
-func (in *DigdiratorStatus) GetSynchronizationHash() string {
-	return in.SynchronizationHash
-}
-
-func (in *DigdiratorStatus) SetHash(hash string) {
-	in.SynchronizationHash = hash
-}
-
-func (in *DigdiratorStatus) SetStateSynchronized() {
+func (in *DigdiratorStatus) SetState(state string) {
 	now := metav1.Now()
 	in.SynchronizationTime = &now
-	in.SynchronizationState = events.Synchronized
-}
-
-func (in *DigdiratorStatus) GetClientID() string {
-	return in.ClientID
-}
-
-func (in *DigdiratorStatus) SetClientID(clientID string) {
-	in.ClientID = clientID
-}
-
-func (in *DigdiratorStatus) SetCorrelationID(correlationID string) {
-	in.CorrelationID = correlationID
-}
-
-func (in *DigdiratorStatus) GetKeyIDs() []string {
-	return in.KeyIDs
-}
-
-func (in *DigdiratorStatus) SetKeyIDs(keyIDs []string) {
-	in.KeyIDs = keyIDs
-}
-
-func (in *DigdiratorStatus) SetSynchronizationState(state string) {
 	in.SynchronizationState = state
 }
 
-func (in *DigdiratorStatus) GetSynchronizationSecretName() string {
-	return in.SynchronizationSecretName
+func (in *DigdiratorStatus) SetStateSynchronized() {
+	in.SetState(events.Synchronized)
 }
 
-func (in *DigdiratorStatus) SetSynchronizationSecretName(name string) {
-	in.SynchronizationSecretName = name
+func (in *DigdiratorStatus) SetCondition(condition metav1.Condition) {
+	if in.Conditions == nil {
+		in.Conditions = &[]metav1.Condition{}
+	}
+
+	meta.SetStatusCondition(in.Conditions, condition)
 }
 
 func init() {

--- a/pkg/apis/nais.io/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/nais.io/v1/zz_generated.deepcopy.go
@@ -5,8 +5,8 @@
 package nais_io_v1
 
 import (
-	"k8s.io/api/apps/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -818,6 +818,22 @@ func (in *DigdiratorStatus) DeepCopyInto(out *DigdiratorStatus) {
 		in, out := &in.KeyIDs, &out.KeyIDs
 		*out = make([]string, len(*in))
 		copy(*out, *in)
+	}
+	if in.ObservedGeneration != nil {
+		in, out := &in.ObservedGeneration, &out.ObservedGeneration
+		*out = new(int64)
+		**out = **in
+	}
+	if in.Conditions != nil {
+		in, out := &in.Conditions, &out.Conditions
+		*out = new([]v1.Condition)
+		if **in != nil {
+			in, out := *in, *out
+			*out = make([]v1.Condition, len(*in))
+			for i := range *in {
+				(*in)[i].DeepCopyInto(&(*out)[i])
+			}
+		}
 	}
 }
 
@@ -2122,10 +2138,10 @@ func (in *Status) DeepCopyInto(out *Status) {
 	*out = *in
 	if in.Conditions != nil {
 		in, out := &in.Conditions, &out.Conditions
-		*out = new([]metav1.Condition)
+		*out = new([]v1.Condition)
 		if **in != nil {
 			in, out := *in, *out
-			*out = make([]metav1.Condition, len(*in))
+			*out = make([]v1.Condition, len(*in))
 			for i := range *in {
 				(*in)[i].DeepCopyInto(&(*out)[i])
 			}
@@ -2148,7 +2164,7 @@ func (in *Strategy) DeepCopyInto(out *Strategy) {
 	*out = *in
 	if in.RollingUpdate != nil {
 		in, out := &in.RollingUpdate, &out.RollingUpdate
-		*out = new(v1.RollingUpdateDeployment)
+		*out = new(appsv1.RollingUpdateDeployment)
 		(*in).DeepCopyInto(*out)
 	}
 }


### PR DESCRIPTION
This is in preparation for Digdirator to use the `generation` metadata field instead of hashes. We'll keep the hash field for backwards compatibility and continue to set it for newer versions of Digdirator, so this isn't a breaking change.

Using the `generation` metadata field is more or less equivalent to using hashes, the differences being that:
- `generation` is a read-only field managed by the API-server
- the value is a strictly monotonically increasing number
- the value only changes when `spec` is modified

Its use is mentioned in the [Kubernetes api-conventions document](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties)

The `conditions` field is a de facto standard status field that allows us to show status messages for the given object in a more persistent manner compared to `Events`.

Also clean up (i.e. mostly remove) getters and setters for the `DigdiratorStatus` struct.