### PR TITLE
Our users should have explicit instructions for what's required

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+# Export all:
+# - (should be) .gitignored
+# - (potentially) secret environment variables
+# - from dotenv-formatted files w/names starting w/`.env`
+DOTENV_FILES="$(find . -maxdepth 1 -type f -name '.env*'\
+  -and -not -name '.envrc'\
+  -and -not -name '.env.example'\
+)"
+for file in ${DOTENV_FILES}; do
+  dotenv "${file}"
+done
+export DOTENV_FILES
+
+if which nix 2>&1 >/dev/null; then
+  use flake
+fi

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,7 @@
 
 # Generated documentation
 /doc/output
+
+# Nix stuffs
+.direnv/
+result*

--- a/charts/templates/nais.io_applications.yaml
+++ b/charts/templates/nais.io_applications.yaml
@@ -1152,6 +1152,7 @@ spec:
                 description: |-
                   OpenSearch instance to get credentials for.
                   Must be owned by same team.
+                  The team must themselves apply an `opensearch` resource, as specified in [how to create an OpenSearch Instance](https://doc.nais.io/persistence/opensearch/how-to/create)
                 properties:
                   access:
                     description: Access level for OpenSearch user

--- a/config/crd/bases/nais.io_applications.yaml
+++ b/config/crd/bases/nais.io_applications.yaml
@@ -1152,6 +1152,7 @@ spec:
                 description: |-
                   OpenSearch instance to get credentials for.
                   Must be owned by same team.
+                  The team must themselves apply an `opensearch` resource, as specified in [how to create an OpenSearch Instance](https://doc.nais.io/persistence/opensearch/how-to/create)
                 properties:
                   access:
                     description: Access level for OpenSearch user

--- a/pkg/apis/nais.io/v1alpha1/application_types.go
+++ b/pkg/apis/nais.io/v1alpha1/application_types.go
@@ -159,6 +159,7 @@ type ApplicationSpec struct {
 
 	// OpenSearch instance to get credentials for.
 	// Must be owned by same team.
+	// The team must themselves apply an `opensearch` resource, as specified in [how to create an OpenSearch Instance](https://doc.nais.io/persistence/opensearch/how-to/create)
 	// +nais:doc:Link="https://doc.nais.io/persistence/opensearch/"
 	OpenSearch *nais_io_v1.OpenSearch `json:"openSearch,omitempty"`
 


### PR DESCRIPTION
- **localDev: Nixify everything**
- **doc: OpenSearch Instances require manual creation**
