### PR TITLE
Make secretName required in services; optional for AivenApplication

### DIFF
--- a/charts/templates/aiven.nais.io_aivenapplications.yaml
+++ b/charts/templates/aiven.nais.io_aivenapplications.yaml
@@ -83,6 +83,7 @@ spec:
                     type: string
                 required:
                 - pool
+                - secretName
                 type: object
               openSearch:
                 description: OpenSearch is a section configuring the OpenSearch credentials
@@ -104,6 +105,8 @@ spec:
                     description: SecretName is the name of the secret containing Aiven
                       credentials for the OpensSearch serviceuser
                     type: string
+                required:
+                - secretName
                 type: object
               protected:
                 description: A Protected secret will not be deleted by the janitor
@@ -134,10 +137,10 @@ spec:
                       description: SecretName is the name of the secret containing
                         Aiven credentials for the Valkey serviceuser
                       type: string
+                  required:
+                  - secretName
                   type: object
                 type: array
-            required:
-            - secretName
             type: object
           status:
             properties:

--- a/charts/templates/aiven.nais.io_aivenapplications.yaml
+++ b/charts/templates/aiven.nais.io_aivenapplications.yaml
@@ -83,7 +83,6 @@ spec:
                     type: string
                 required:
                 - pool
-                - secretName
                 type: object
               openSearch:
                 description: OpenSearch is a section configuring the OpenSearch credentials
@@ -98,15 +97,11 @@ spec:
                     - admin
                     type: string
                   instance:
-                    description: Use the `instance_name` that you specified in the
-                      [navikt/aiven-iac](https://github.com/navikt/aiven-iac) repository.
                     type: string
                   secretName:
                     description: SecretName is the name of the secret containing Aiven
                       credentials for the OpensSearch serviceuser
                     type: string
-                required:
-                - secretName
                 type: object
               protected:
                 description: A Protected secret will not be deleted by the janitor
@@ -137,8 +132,6 @@ spec:
                       description: SecretName is the name of the secret containing
                         Aiven credentials for the Valkey serviceuser
                       type: string
-                  required:
-                  - secretName
                   type: object
                 type: array
             type: object

--- a/config/crd/bases/aiven.nais.io_aivenapplications.yaml
+++ b/config/crd/bases/aiven.nais.io_aivenapplications.yaml
@@ -83,6 +83,7 @@ spec:
                     type: string
                 required:
                 - pool
+                - secretName
                 type: object
               openSearch:
                 description: OpenSearch is a section configuring the OpenSearch credentials
@@ -104,6 +105,8 @@ spec:
                     description: SecretName is the name of the secret containing Aiven
                       credentials for the OpensSearch serviceuser
                     type: string
+                required:
+                - secretName
                 type: object
               protected:
                 description: A Protected secret will not be deleted by the janitor
@@ -134,10 +137,10 @@ spec:
                       description: SecretName is the name of the secret containing
                         Aiven credentials for the Valkey serviceuser
                       type: string
+                  required:
+                  - secretName
                   type: object
                 type: array
-            required:
-            - secretName
             type: object
           status:
             properties:

--- a/config/crd/bases/aiven.nais.io_aivenapplications.yaml
+++ b/config/crd/bases/aiven.nais.io_aivenapplications.yaml
@@ -83,7 +83,6 @@ spec:
                     type: string
                 required:
                 - pool
-                - secretName
                 type: object
               openSearch:
                 description: OpenSearch is a section configuring the OpenSearch credentials
@@ -98,15 +97,11 @@ spec:
                     - admin
                     type: string
                   instance:
-                    description: Use the `instance_name` that you specified in the
-                      [navikt/aiven-iac](https://github.com/navikt/aiven-iac) repository.
                     type: string
                   secretName:
                     description: SecretName is the name of the secret containing Aiven
                       credentials for the OpensSearch serviceuser
                     type: string
-                required:
-                - secretName
                 type: object
               protected:
                 description: A Protected secret will not be deleted by the janitor
@@ -137,8 +132,6 @@ spec:
                       description: SecretName is the name of the secret containing
                         Aiven credentials for the Valkey serviceuser
                       type: string
-                  required:
-                  - secretName
                   type: object
                 type: array
             type: object

--- a/flake.lock
+++ b/flake.lock
@@ -2,22 +2,44 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1697710884,
-        "narHash": "sha256-wzqzC4UWUFh59cOF2QVIyU+TJW6OOlbXt4ar2QmOQKg=",
+        "lastModified": 1751949589,
+        "narHash": "sha256-mgFxAPLWw0Kq+C8P3dRrZrOYEQXOtKuYVlo9xvPntt8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5158d2ef4d3aba5080b128f4fc3387e7731ffb20",
+        "rev": "9b008d60392981ad674e04016d25619281550a9d",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
     "root": {
       "inputs": {
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "treefmt-nix": "treefmt-nix"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1752055615,
+        "narHash": "sha256-19m7P4O/Aw/6+CzncWMAJu89JaKeMh3aMle1CNQSIwM=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "c9d477b5d5bd7f26adddd3f96cfd6a904768d4f9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -1,14 +1,50 @@
 {
-  description = "gostuff";
+  description = "Collection of small Go libraries used by nais K8s operators";
 
   # Flake inputs
-  inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs"; # also valid: "nixpkgs"
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+  inputs.treefmt-nix = {
+    url = "github:numtide/treefmt-nix";
+    inputs.nixpkgs.follows = "nixpkgs";
   };
 
   # Flake outputs
-  outputs = { self, nixpkgs }:
+  outputs =
+    inputs:
     let
+      goOverlay =
+        final: prev:
+        let
+          nixpkgsGo = prev.go;
+          firstSemverGeqSecond = first: second: builtins.compareVersions first second >= 0;
+          goModFileVersion = builtins.elemAt (builtins.match ".*\ngo ([0-9a\.a-z]+).*" (builtins.readFile ./go.mod)) 0;
+
+          projectGo =
+            if (firstSemverGeqSecond nixpkgsGo.version goModFileVersion) then
+              builtins.trace "Using nixpkgs' Go version: ${nixpkgsGo.version}" nixpkgsGo
+            else
+              (
+                if (firstSemverGeqSecond upstream.version nixpkgsGo.version) then
+                  builtins.warn "Using `upstream`'s Go version: ${upstream.version}, update nixpkgs?"
+                    prev.go.overrideAttrs
+                    (_: {
+                      src = prev.fetchurl rec {
+                        inherit (upstream) hash version;
+                        url = "https://go.dev/dl/go${version}.src.tar.gz";
+                      };
+                    })
+                else
+                  builtins.abort "!!! UPDATE nixpkgs or `upstream` Go's referenced version to match the one `go.mod` requires!"
+                # See below:
+              );
+
+          upstream.version = "1.23.0"; # Change us when above error is thrown
+          upstream.hash = "sha256-Qreo6A2AXaoDAi7T/eQyHUw78smQoUQWXQHu7Nb2mcY="; # Change us when above error is thrown
+        in
+        {
+          go = projectGo;
+          buildGoModule = prev.buildGoModule.override { inherit (final) go; };
+        };
       # Systems supported
       allSystems = [
         "x86_64-linux" # 64-bit Intel/AMD Linux
@@ -18,16 +54,67 @@
       ];
 
       # Helper to provide system-specific attributes
-      forAllSystems = f:
-        nixpkgs.lib.genAttrs allSystems
-        (system: f { pkgs = import nixpkgs { inherit system; }; });
-    in {
+      forAllSystems =
+        f:
+        inputs.nixpkgs.lib.genAttrs allSystems (
+          system:
+          f rec {
+            inherit (pkgs) lib;
+            pkgs = import inputs.nixpkgs {
+              inherit system;
+              overlays = [ goOverlay ];
+            };
+          }
+        );
+    in
+    {
       # Development environment output
-      devShells = forAllSystems ({ pkgs }: {
-        default = pkgs.mkShell {
-          # The Nix packages provided in the environment
-          packages = with pkgs; [ go_1_21 gotools gopls go-mockery ];
-        };
-      });
+      devShells = forAllSystems (
+        { pkgs, ... }:
+        {
+          default = pkgs.mkShell {
+            # The Nix packages provided in the environment
+            packages = with pkgs; [
+              go
+              go-mockery
+              gofumpt
+              gopls
+              gotools
+            ];
+          };
+        }
+      );
+      formatter = forAllSystems (
+        { pkgs, lib, ... }:
+        inputs.treefmt-nix.lib.mkWrapper pkgs (
+          {
+            projectRootFile = "flake.nix";
+            settings.global.excludes = [
+              "*.md"
+              ".gitattributes"
+            ];
+          }
+          // {
+            programs =
+              lib.genAttrs
+                [
+                  # General
+                  "shellcheck"
+                  "dos2unix"
+
+                  # go
+                  "gofumpt"
+
+                  # nix
+                  "statix"
+                  "nixfmt"
+                  "deadnix"
+                ]
+                (_: {
+                  enable = true;
+                });
+          }
+        )
+      );
     };
 }

--- a/pkg/apis/aiven.nais.io/v1/aiven_application_types.go
+++ b/pkg/apis/aiven.nais.io/v1/aiven_application_types.go
@@ -43,15 +43,21 @@ type AivenApplication struct {
 	Status            AivenApplicationStatus `json:"status,omitempty"`
 }
 
+type KafkaSpec struct {
+	// Pool is the Kafka pool (aka cluster) on Aiven this application uses
+	Pool string `json:"pool"`
+	// SecretName is the name of the secret for the Kafka pool
+	SecretName string `json:"secretName,omitempty"`
+}
+
 type OpenSearchSpec struct {
-	// Use the `instance_name` that you specified in the [navikt/aiven-iac](https://github.com/navikt/aiven-iac) repository.
 	Instance string `json:"instance,omitempty"`
 	// Access level for opensearch user
 	// +kubebuilder:validation:Enum=read;write;readwrite;admin
 	// +nais:doc:Default="read"
 	Access string `json:"access,omitempty"`
 	// SecretName is the name of the secret containing Aiven credentials for the OpensSearch serviceuser
-	SecretName string `json:"secretName"`
+	SecretName string `json:"secretName,omitempty"`
 }
 
 type ValkeySpec struct {
@@ -62,7 +68,7 @@ type ValkeySpec struct {
 	// +nais:doc:Default="read"
 	Access string `json:"access,omitempty"`
 	// SecretName is the name of the secret containing Aiven credentials for the Valkey serviceuser
-	SecretName string `json:"secretName"`
+	SecretName string `json:"secretName,omitempty"`
 }
 
 type AivenApplicationSpec struct {
@@ -81,13 +87,6 @@ type AivenApplicationSpec struct {
 	OpenSearch *OpenSearchSpec `json:"openSearch,omitempty"`
 	// Valkey is a section configuring the Valkey credentials to provision
 	Valkey []*ValkeySpec `json:"valkey,omitempty"`
-}
-
-type KafkaSpec struct {
-	// Pool is the Kafka pool (aka cluster) on Aiven this application uses
-	Pool string `json:"pool"`
-	// SecretName is the name of the secret for the Kafka pool
-	SecretName string `json:"secretName"`
 }
 
 type AivenApplicationConditionType string

--- a/pkg/apis/aiven.nais.io/v1/aiven_application_types.go
+++ b/pkg/apis/aiven.nais.io/v1/aiven_application_types.go
@@ -51,7 +51,7 @@ type OpenSearchSpec struct {
 	// +nais:doc:Default="read"
 	Access string `json:"access,omitempty"`
 	// SecretName is the name of the secret containing Aiven credentials for the OpensSearch serviceuser
-	SecretName string `json:"secretName,omitempty"`
+	SecretName string `json:"secretName"`
 }
 
 type ValkeySpec struct {
@@ -62,12 +62,12 @@ type ValkeySpec struct {
 	// +nais:doc:Default="read"
 	Access string `json:"access,omitempty"`
 	// SecretName is the name of the secret containing Aiven credentials for the Valkey serviceuser
-	SecretName string `json:"secretName,omitempty"`
+	SecretName string `json:"secretName"`
 }
 
 type AivenApplicationSpec struct {
 	// SecretName is the name of the secret containing Aiven credentials
-	SecretName string `json:"secretName"`
+	SecretName string `json:"secretName,omitempty"`
 	// A Protected secret will not be deleted by the janitor even when not in use
 	Protected bool `json:"protected,omitempty"`
 	// A timestamp that indicates time-to-expire-date for personal secrets.
@@ -87,7 +87,7 @@ type KafkaSpec struct {
 	// Pool is the Kafka pool (aka cluster) on Aiven this application uses
 	Pool string `json:"pool"`
 	// SecretName is the name of the secret for the Kafka pool
-	SecretName string `json:"secretName,omitempty"`
+	SecretName string `json:"secretName"`
 }
 
 type AivenApplicationConditionType string

--- a/pkg/apis/aiven.nais.io/v1/hash_test.go
+++ b/pkg/apis/aiven.nais.io/v1/hash_test.go
@@ -9,12 +9,10 @@ func Test_hash(t *testing.T) {
 		want     string
 		wantErr  bool
 	}{
-		{name: "ClearAivenApplication", aivenapp: &AivenApplication{}, want: "b2b67239ec384acc", wantErr: false},
+		{name: "ClearAivenApplication", aivenapp: &AivenApplication{}, want: "9265f549ad56469c", wantErr: false},
 		{name: "AivenApplicationWithSecretName", aivenapp: &AivenApplication{
-			Spec: AivenApplicationSpec{
-				SecretName: "this-is-my-secret",
-			},
-		}, want: "743f9f56c913003d", wantErr: false},
+			Spec: AivenApplicationSpec{},
+		}, want: "9265f549ad56469c", wantErr: false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
- Set `secretName` as a required field (remove `omitempty`) in `OpenSearchSpec`, `ValkeySpec`, and `KafkaSpec` to enforce credential naming.
- Set `secretName` as optional (`omitempty`) in `AivenApplicationSpec` to allow flexibility.
- Updates improve schema clarity and validation.