### PR TITLE
fix: skip update validation when resource is being deleted

### DIFF
--- a/pkg/apis/nais.io/v1/webhook.go
+++ b/pkg/apis/nais.io/v1/webhook.go
@@ -71,7 +71,10 @@ func (v *JobValidator) ValidateCreate(ctx context.Context, nj *Naisjob) (warning
 }
 
 func (v *JobValidator) ValidateUpdate(ctx context.Context, oldA *Naisjob, nj *Naisjob) (warnings admission.Warnings, err error) {
-	// Perform actual comparison
+	if !nj.GetDeletionTimestamp().IsZero() {
+		return nil, nil
+	}
+
 	if err := webhookvalidator.NaisCompare(nj.Spec, oldA.Spec, field.NewPath("spec")); err != nil {
 		if allErrs, ok := err.(errors.Aggregate); ok {
 			return nil, apierrors.NewInvalid(

--- a/pkg/apis/nais.io/v1/webhook_test.go
+++ b/pkg/apis/nais.io/v1/webhook_test.go
@@ -452,6 +452,39 @@ func TestJobValidator_ValidateUpdate(t *testing.T) {
 		assert.Contains(t, err.Error(), "OpenSearch 'nonexistent-opensearch' does not exist")
 		assert.Empty(t, warnings)
 	})
+
+	t.Run("update with deletion timestamp skips validation", func(t *testing.T) {
+		// Finalizer removal goes through the update admission path. Validation
+		// must short-circuit so missing references do not block deletion.
+		validator := &JobValidator{Client: fakeKubeClient()}
+		oldNj := &Naisjob{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-job",
+				Namespace: "test-ns",
+			},
+			Spec: NaisjobSpec{
+				Image:    "nginx:latest",
+				Schedule: "0 * * * *",
+			},
+		}
+		newNj := oldNj.DeepCopy()
+		now := metav1.Now()
+		newNj.DeletionTimestamp = &now
+		// Intentionally point to non-existent references; they must not trigger checks.
+		newNj.Spec.OpenSearch = &OpenSearch{
+			Instance: "nonexistent-opensearch",
+		}
+		newNj.Spec.Valkey = []Valkey{
+			{Instance: "nonexistent-valkey"},
+		}
+		newNj.Spec.Postgres = &Postgres{
+			ClusterName: "nonexistent-postgres",
+		}
+
+		warnings, err := validator.ValidateUpdate(t.Context(), oldNj, newNj)
+		assert.NoError(t, err)
+		assert.Empty(t, warnings)
+	})
 }
 
 func TestJobValidator_ValidateDelete(t *testing.T) {

--- a/pkg/apis/nais.io/v1alpha1/webhook.go
+++ b/pkg/apis/nais.io/v1alpha1/webhook.go
@@ -71,7 +71,10 @@ func (v *ApplicationValidator) ValidateCreate(ctx context.Context, a *Applicatio
 }
 
 func (v *ApplicationValidator) ValidateUpdate(ctx context.Context, oldA *Application, a *Application) (warnings admission.Warnings, err error) {
-	// Perform actual comparison
+	if !a.GetDeletionTimestamp().IsZero() {
+		return nil, nil
+	}
+
 	if err := webhookvalidator.NaisCompare(a.Spec, oldA.Spec, field.NewPath("spec")); err != nil {
 		if allErrs, ok := err.(errors.Aggregate); ok {
 			return nil, apierrors.NewInvalid(

--- a/pkg/apis/nais.io/v1alpha1/webhook_test.go
+++ b/pkg/apis/nais.io/v1alpha1/webhook_test.go
@@ -464,6 +464,44 @@ func TestApplicationValidator_ValidateUpdate(t *testing.T) {
 		assert.Contains(t, err.Error(), "OpenSearch 'nonexistent-opensearch' does not exist")
 		assert.Empty(t, warnings)
 	})
+
+	t.Run("update with deletion timestamp skips validation", func(t *testing.T) {
+		// Finalizer removal goes through the update admission path. Validation
+		// must short-circuit so missing references do not block deletion.
+		validator := &ApplicationValidator{Client: fakeKubeClient()}
+		oldApp := &Application{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-app",
+				Namespace: "test-ns",
+			},
+			Spec: ApplicationSpec{
+				Image: "nginx:latest",
+			},
+		}
+		newApp := oldApp.DeepCopy()
+		now := metav1.Now()
+		newApp.DeletionTimestamp = &now
+		// Intentionally point to a non-existent reference; it must not trigger a check.
+		newApp.Spec.OpenSearch = &nais_io_v1.OpenSearch{
+			Instance: "nonexistent-opensearch",
+		}
+		newApp.Spec.Valkey = []nais_io_v1.Valkey{
+			{Instance: "nonexistent-valkey"},
+		}
+		newApp.Spec.Postgres = &nais_io_v1.Postgres{
+			ClusterName: "nonexistent-postgres",
+		}
+		// Also introduce an otherwise-disallowed spec change to verify NaisCompare is skipped.
+		newApp.Spec.GCP = &nais_io_v1.GCP{
+			BigQueryDatasets: []nais_io_v1.CloudBigQueryDataset{
+				{Name: "dataset1", Permission: nais_io_v1.BigQueryPermissionRead},
+			},
+		}
+
+		warnings, err := validator.ValidateUpdate(t.Context(), oldApp, newApp)
+		assert.NoError(t, err)
+		assert.Empty(t, warnings)
+	})
 }
 
 func TestApplicationValidator_ValidateDelete(t *testing.T) {


### PR DESCRIPTION
Finalizer removal goes through the update admission path. Blocking it on reference checks (Postgres, OpenSearch, Valkey) can deadlock deletion when the referenced resource has already been removed.