### PR TITLE
Revert "feat: bigquery.spec.project er deprecated"

### DIFF
--- a/charts/templates/google.nais.io_bigquerydatasets.yaml
+++ b/charts/templates/google.nais.io_bigquerydatasets.yaml
@@ -68,6 +68,8 @@ spec:
                 type: string
               name:
                 type: string
+              project:
+                type: string
             required:
             - location
             - name

--- a/config/crd/bases/google.nais.io_bigquerydatasets.yaml
+++ b/config/crd/bases/google.nais.io_bigquerydatasets.yaml
@@ -68,6 +68,8 @@ spec:
                 type: string
               name:
                 type: string
+              project:
+                type: string
             required:
             - location
             - name

--- a/pkg/apis/google.nais.io/v1/bigquery_dataset_types.go
+++ b/pkg/apis/google.nais.io/v1/bigquery_dataset_types.go
@@ -25,6 +25,7 @@ type BigQueryDatasetSpec struct {
 	// +kubebuilder:validation:Enum=europe-north1
 	Location        string          `json:"location"`
 	Access          []DatasetAccess `json:"access,omitempty"`
+	Project         string          `json:"project"`
 	CascadingDelete bool            `json:"cascadingDelete,omitempty"`
 }
 


### PR DESCRIPTION
Still in use by https://github.com/nais/bqrator/blob/b54ac5aa8098cb336cfc757d230dd65d2646fbd8/controllers/bigquerydataset_controller.go#L118.
This reverts commit d210b3565e8fee97d145b54c19c57a3c5c26b8e5.
