### PR TITLE
fix(scheme): register group-version meta types

### DIFF
--- a/pkg/apis/aiven.io/v1alpha1/meta.go
+++ b/pkg/apis/aiven.io/v1alpha1/meta.go
@@ -5,6 +5,7 @@
 package aiven_io_v1alpha1
 
 import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
@@ -18,7 +19,10 @@ var (
 	// renamed to SchemeGroupVersion???
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
-	SchemeBuilder = runtime.NewSchemeBuilder()
+	SchemeBuilder = runtime.NewSchemeBuilder(func(s *runtime.Scheme) error {
+		metav1.AddToGroupVersion(s, GroupVersion)
+		return nil
+	})
 
 	// AddToScheme adds the types in this group-version to the given scheme.
 	AddToScheme = SchemeBuilder.AddToScheme

--- a/pkg/apis/aiven.nais.io/v1/meta.go
+++ b/pkg/apis/aiven.nais.io/v1/meta.go
@@ -5,6 +5,7 @@
 package aiven_nais_io_v1
 
 import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
@@ -15,7 +16,10 @@ var (
 	// renamed to SchemeGroupVersion???
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
-	SchemeBuilder = runtime.NewSchemeBuilder()
+	SchemeBuilder = runtime.NewSchemeBuilder(func(s *runtime.Scheme) error {
+		metav1.AddToGroupVersion(s, GroupVersion)
+		return nil
+	})
 
 	// AddToScheme adds the types in this group-version to the given scheme.
 	AddToScheme = SchemeBuilder.AddToScheme

--- a/pkg/apis/aiven.nais.io/v2/meta.go
+++ b/pkg/apis/aiven.nais.io/v2/meta.go
@@ -5,6 +5,7 @@
 package aiven_nais_io_v2
 
 import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
@@ -15,7 +16,10 @@ var (
 	// renamed to SchemeGroupVersion???
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
-	SchemeBuilder = runtime.NewSchemeBuilder()
+	SchemeBuilder = runtime.NewSchemeBuilder(func(s *runtime.Scheme) error {
+		metav1.AddToGroupVersion(s, GroupVersion)
+		return nil
+	})
 
 	// AddToScheme adds the types in this group-version to the given scheme.
 	AddToScheme = SchemeBuilder.AddToScheme

--- a/pkg/apis/bigquery.cnrm.cloud.google.com/v1beta1/meta.go
+++ b/pkg/apis/bigquery.cnrm.cloud.google.com/v1beta1/meta.go
@@ -4,6 +4,7 @@
 package bigquery_cnrm_cloud_google_com_v1beta1
 
 import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
@@ -13,7 +14,10 @@ var (
 	GroupVersion = schema.GroupVersion{Group: "bigquery.cnrm.cloud.google.com", Version: "v1beta1"}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
-	SchemeBuilder = runtime.NewSchemeBuilder()
+	SchemeBuilder = runtime.NewSchemeBuilder(func(s *runtime.Scheme) error {
+		metav1.AddToGroupVersion(s, GroupVersion)
+		return nil
+	})
 
 	// AddToScheme adds the types in this group-version to the given scheme.
 	AddToScheme = SchemeBuilder.AddToScheme

--- a/pkg/apis/fqdnnetworkpolicies.networking.gke.io/v1alpha3/meta.go
+++ b/pkg/apis/fqdnnetworkpolicies.networking.gke.io/v1alpha3/meta.go
@@ -4,6 +4,7 @@
 package fqdnnetworkpolicies_networking_gke_io_v1alpha3
 
 import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
@@ -13,7 +14,10 @@ var (
 	GroupVersion = schema.GroupVersion{Group: "networking.gke.io", Version: "v1alpha3"}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
-	SchemeBuilder = runtime.NewSchemeBuilder()
+	SchemeBuilder = runtime.NewSchemeBuilder(func(s *runtime.Scheme) error {
+		metav1.AddToGroupVersion(s, GroupVersion)
+		return nil
+	})
 
 	// AddToScheme adds the types in this group-version to the given scheme.
 	AddToScheme = SchemeBuilder.AddToScheme

--- a/pkg/apis/google.nais.io/v1/meta.go
+++ b/pkg/apis/google.nais.io/v1/meta.go
@@ -5,6 +5,7 @@
 package google_nais_io_v1
 
 import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
@@ -14,7 +15,10 @@ var (
 	GroupVersion = schema.GroupVersion{Group: "google.nais.io", Version: "v1"}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
-	SchemeBuilder = runtime.NewSchemeBuilder()
+	SchemeBuilder = runtime.NewSchemeBuilder(func(s *runtime.Scheme) error {
+		metav1.AddToGroupVersion(s, GroupVersion)
+		return nil
+	})
 
 	// AddToScheme adds the types in this group-version to the given scheme.
 	AddToScheme = SchemeBuilder.AddToScheme

--- a/pkg/apis/iam.cnrm.cloud.google.com/v1beta1/meta.go
+++ b/pkg/apis/iam.cnrm.cloud.google.com/v1beta1/meta.go
@@ -5,6 +5,7 @@
 package iam_cnrm_cloud_google_com_v1beta1
 
 import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
@@ -14,7 +15,10 @@ var (
 	GroupVersion = schema.GroupVersion{Group: "iam.cnrm.cloud.google.com", Version: "v1beta1"}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
-	SchemeBuilder = runtime.NewSchemeBuilder()
+	SchemeBuilder = runtime.NewSchemeBuilder(func(s *runtime.Scheme) error {
+		metav1.AddToGroupVersion(s, GroupVersion)
+		return nil
+	})
 
 	// AddToScheme adds the types in this group-version to the given scheme.
 	AddToScheme = SchemeBuilder.AddToScheme

--- a/pkg/apis/kafka.nais.io/v1/meta.go
+++ b/pkg/apis/kafka.nais.io/v1/meta.go
@@ -5,6 +5,7 @@
 package kafka_nais_io_v1
 
 import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
@@ -15,7 +16,10 @@ var (
 	// renamed to SchemeGroupVersion???
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
-	SchemeBuilder = runtime.NewSchemeBuilder()
+	SchemeBuilder = runtime.NewSchemeBuilder(func(s *runtime.Scheme) error {
+		metav1.AddToGroupVersion(s, GroupVersion)
+		return nil
+	})
 
 	// AddToScheme adds the types in this group-version to the given scheme.
 	AddToScheme = SchemeBuilder.AddToScheme

--- a/pkg/apis/nais.io/v1/meta.go
+++ b/pkg/apis/nais.io/v1/meta.go
@@ -5,6 +5,7 @@
 package nais_io_v1
 
 import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
@@ -14,7 +15,10 @@ var (
 	GroupVersion = schema.GroupVersion{Group: "nais.io", Version: "v1"}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
-	SchemeBuilder = runtime.NewSchemeBuilder()
+	SchemeBuilder = runtime.NewSchemeBuilder(func(s *runtime.Scheme) error {
+		metav1.AddToGroupVersion(s, GroupVersion)
+		return nil
+	})
 
 	// AddToScheme adds the types in this group-version to the given scheme.
 	AddToScheme = SchemeBuilder.AddToScheme

--- a/pkg/apis/nais.io/v1alpha1/meta.go
+++ b/pkg/apis/nais.io/v1alpha1/meta.go
@@ -5,6 +5,7 @@
 package nais_io_v1alpha1
 
 import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
@@ -14,7 +15,10 @@ var (
 	GroupVersion = schema.GroupVersion{Group: "nais.io", Version: "v1alpha1"}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
-	SchemeBuilder = runtime.NewSchemeBuilder()
+	SchemeBuilder = runtime.NewSchemeBuilder(func(s *runtime.Scheme) error {
+		metav1.AddToGroupVersion(s, GroupVersion)
+		return nil
+	})
 
 	// AddToScheme adds the types in this group-version to the given scheme.
 	AddToScheme = SchemeBuilder.AddToScheme

--- a/pkg/apis/sql.cnrm.cloud.google.com/v1beta1/meta.go
+++ b/pkg/apis/sql.cnrm.cloud.google.com/v1beta1/meta.go
@@ -4,6 +4,7 @@
 package sql_cnrm_cloud_google_com_v1beta1
 
 import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
@@ -13,7 +14,10 @@ var (
 	GroupVersion = schema.GroupVersion{Group: "sql.cnrm.cloud.google.com", Version: "v1beta1"}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
-	SchemeBuilder = runtime.NewSchemeBuilder()
+	SchemeBuilder = runtime.NewSchemeBuilder(func(s *runtime.Scheme) error {
+		metav1.AddToGroupVersion(s, GroupVersion)
+		return nil
+	})
 
 	// AddToScheme adds the types in this group-version to the given scheme.
 	AddToScheme = SchemeBuilder.AddToScheme

--- a/pkg/apis/storage.cnrm.cloud.google.com/v1beta1/meta.go
+++ b/pkg/apis/storage.cnrm.cloud.google.com/v1beta1/meta.go
@@ -4,6 +4,7 @@
 package storage_cnrm_cloud_google_com_v1beta1
 
 import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
@@ -13,7 +14,10 @@ var (
 	GroupVersion = schema.GroupVersion{Group: "storage.cnrm.cloud.google.com", Version: "v1beta1"}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
-	SchemeBuilder = runtime.NewSchemeBuilder()
+	SchemeBuilder = runtime.NewSchemeBuilder(func(s *runtime.Scheme) error {
+		metav1.AddToGroupVersion(s, GroupVersion)
+		return nil
+	})
 
 	// AddToScheme adds the types in this group-version to the given scheme.
 	AddToScheme = SchemeBuilder.AddToScheme

--- a/pkg/scheme/scheme_test.go
+++ b/pkg/scheme/scheme_test.go
@@ -1,0 +1,54 @@
+package scheme
+
+import (
+	"testing"
+
+	aiven_io_v1alpha1 "github.com/nais/liberator/pkg/apis/aiven.io/v1alpha1"
+	aiven_nais_io_v1 "github.com/nais/liberator/pkg/apis/aiven.nais.io/v1"
+	aiven_nais_io_v2 "github.com/nais/liberator/pkg/apis/aiven.nais.io/v2"
+	bigquery_cnrm_cloud_google_com_v1beta1 "github.com/nais/liberator/pkg/apis/bigquery.cnrm.cloud.google.com/v1beta1"
+	fdqnnetworkpolicies_networking_gke_io_v1alpha3 "github.com/nais/liberator/pkg/apis/fqdnnetworkpolicies.networking.gke.io/v1alpha3"
+	google_nais_io_v1 "github.com/nais/liberator/pkg/apis/google.nais.io/v1"
+	iam_cnrm_cloud_google_com_v1beta1 "github.com/nais/liberator/pkg/apis/iam.cnrm.cloud.google.com/v1beta1"
+	kafka_nais_io_v1 "github.com/nais/liberator/pkg/apis/kafka.nais.io/v1"
+	nais_io_v1 "github.com/nais/liberator/pkg/apis/nais.io/v1"
+	nais_io_v1alpha1 "github.com/nais/liberator/pkg/apis/nais.io/v1alpha1"
+	sql_cnrm_cloud_google_com_v1beta1 "github.com/nais/liberator/pkg/apis/sql.cnrm.cloud.google.com/v1beta1"
+	storage_cnrm_cloud_google_com_v1beta1 "github.com/nais/liberator/pkg/apis/storage.cnrm.cloud.google.com/v1beta1"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+)
+
+func TestAddToSchemeRegistersMetaTypes(t *testing.T) {
+	tests := []struct {
+		name         string
+		groupVersion schema.GroupVersion
+		addToScheme  func(*runtime.Scheme) error
+	}{
+		{"aiven.io/v1alpha1", aiven_io_v1alpha1.GroupVersion, aiven_io_v1alpha1.AddToScheme},
+		{"aiven.nais.io/v1", aiven_nais_io_v1.GroupVersion, aiven_nais_io_v1.AddToScheme},
+		{"aiven.nais.io/v2", aiven_nais_io_v2.GroupVersion, aiven_nais_io_v2.AddToScheme},
+		{"bigquery.cnrm.cloud.google.com/v1beta1", bigquery_cnrm_cloud_google_com_v1beta1.GroupVersion, bigquery_cnrm_cloud_google_com_v1beta1.AddToScheme},
+		{"fqdnnetworkpolicies.networking.gke.io/v1alpha3", fdqnnetworkpolicies_networking_gke_io_v1alpha3.GroupVersion, fdqnnetworkpolicies_networking_gke_io_v1alpha3.AddToScheme},
+		{"google.nais.io/v1", google_nais_io_v1.GroupVersion, google_nais_io_v1.AddToScheme},
+		{"iam.cnrm.cloud.google.com/v1beta1", iam_cnrm_cloud_google_com_v1beta1.GroupVersion, iam_cnrm_cloud_google_com_v1beta1.AddToScheme},
+		{"kafka.nais.io/v1", kafka_nais_io_v1.GroupVersion, kafka_nais_io_v1.AddToScheme},
+		{"nais.io/v1", nais_io_v1.GroupVersion, nais_io_v1.AddToScheme},
+		{"nais.io/v1alpha1", nais_io_v1alpha1.GroupVersion, nais_io_v1alpha1.AddToScheme},
+		{"sql.cnrm.cloud.google.com/v1beta1", sql_cnrm_cloud_google_com_v1beta1.GroupVersion, sql_cnrm_cloud_google_com_v1beta1.AddToScheme},
+		{"storage.cnrm.cloud.google.com/v1beta1", storage_cnrm_cloud_google_com_v1beta1.GroupVersion, storage_cnrm_cloud_google_com_v1beta1.AddToScheme},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scheme := runtime.NewScheme()
+			require.NoError(t, clientgoscheme.AddToScheme(scheme))
+			require.NoError(t, tt.addToScheme(scheme))
+			_, err := scheme.ConvertToVersion(&metav1.CreateOptions{}, tt.groupVersion)
+			require.NoError(t, err)
+		})
+	}
+}


### PR DESCRIPTION
Restore the metav1.AddToGroupVersion registration removed by 80fce92.

The controller-runtime Builder migration path registers these types alongside known API types: https://github.com/kubernetes-sigs/controller-runtime/blob/d3cf8dddbb6a166154bb9d385cd83c712f10595f/pkg/scheme/scheme.go#L62-L91

Without it, converting core v1.CreateOptions to a Liberator API group/version fails, e.g. when using client-go to operate on the resources.